### PR TITLE
[Feat] #20 - CustomDatePicker, getKrDate 구현했습니다. 

### DIFF
--- a/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
+++ b/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2D4EE3852C3D6E6B00E3E95B /* CustomProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3842C3D6E6B00E3E95B /* CustomProgressView.swift */; };
-		2D4EE3892C3D9EA400E3E95B /* getKrDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3882C3D9EA400E3E95B /* getKrDate.swift */; };
+		2D4EE3892C3D9EA400E3E95B /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3882C3D9EA400E3E95B /* Date+.swift */; };
 		2D4EE38B2C3D9FD900E3E95B /* CustomDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE38A2C3D9FD900E3E95B /* CustomDatePicker.swift */; };
 		7121A1332C396FB40056DB8B /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1322C396FB40056DB8B /* CustomButton.swift */; };
 		7121A1352C39CCF60056DB8B /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1342C39CCF60056DB8B /* UIButton+.swift */; };
@@ -50,7 +50,7 @@
 
 /* Begin PBXFileReference section */
 		2D4EE3842C3D6E6B00E3E95B /* CustomProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomProgressView.swift; sourceTree = "<group>"; };
-		2D4EE3882C3D9EA400E3E95B /* getKrDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = getKrDate.swift; sourceTree = "<group>"; };
+		2D4EE3882C3D9EA400E3E95B /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		2D4EE38A2C3D9FD900E3E95B /* CustomDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDatePicker.swift; sourceTree = "<group>"; };
 		7121A1322C396FB40056DB8B /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		7121A1342C39CCF60056DB8B /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
@@ -156,6 +156,7 @@
 		7121A14D2C3B09BF0056DB8B /* Foundation+ */ = {
 			isa = PBXGroup;
 			children = (
+				2D4EE3882C3D9EA400E3E95B /* Date+.swift */,
 				7121A1502C3B09E10056DB8B /* Result+.swift */,
 			);
 			path = "Foundation+";
@@ -291,7 +292,6 @@
 				71E3C4112C243BDD0026C4DD /* getClassName.swift */,
 				7121A13D2C3A98E10056DB8B /* LabelFactory.swift */,
 				7121A14A2C3B09800056DB8B /* setImage.swift */,
-				2D4EE3882C3D9EA400E3E95B /* getKrDate.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -428,7 +428,7 @@
 				7121A14B2C3B09800056DB8B /* setImage.swift in Sources */,
 				2D4EE3852C3D6E6B00E3E95B /* CustomProgressView.swift in Sources */,
 				7121A1332C396FB40056DB8B /* CustomButton.swift in Sources */,
-				2D4EE3892C3D9EA400E3E95B /* getKrDate.swift in Sources */,
+				2D4EE3892C3D9EA400E3E95B /* Date+.swift in Sources */,
 				71461ED62C38150C002A6999 /* UILabel+.swift in Sources */,
 				71D7E6ED2C2FF42500C54EA7 /* TNTabBarController.swift in Sources */,
 				7121A1492C3B08360056DB8B /* JobDetailModel.swift in Sources */,

--- a/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
+++ b/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		2D4EE3852C3D6E6B00E3E95B /* CustomProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3842C3D6E6B00E3E95B /* CustomProgressView.swift */; };
+		2D4EE3892C3D9EA400E3E95B /* getKrDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3882C3D9EA400E3E95B /* getKrDate.swift */; };
+		2D4EE38B2C3D9FD900E3E95B /* CustomDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE38A2C3D9FD900E3E95B /* CustomDatePicker.swift */; };
 		7121A1332C396FB40056DB8B /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1322C396FB40056DB8B /* CustomButton.swift */; };
 		7121A1352C39CCF60056DB8B /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1342C39CCF60056DB8B /* UIButton+.swift */; };
 		7121A1372C3A6C7C0056DB8B /* CustomAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1362C3A6C7C0056DB8B /* CustomAlertViewController.swift */; };
@@ -48,6 +50,8 @@
 
 /* Begin PBXFileReference section */
 		2D4EE3842C3D6E6B00E3E95B /* CustomProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomProgressView.swift; sourceTree = "<group>"; };
+		2D4EE3882C3D9EA400E3E95B /* getKrDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = getKrDate.swift; sourceTree = "<group>"; };
+		2D4EE38A2C3D9FD900E3E95B /* CustomDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDatePicker.swift; sourceTree = "<group>"; };
 		7121A1322C396FB40056DB8B /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		7121A1342C39CCF60056DB8B /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		7121A1362C3A6C7C0056DB8B /* CustomAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertViewController.swift; sourceTree = "<group>"; };
@@ -107,6 +111,7 @@
 				7121A1322C396FB40056DB8B /* CustomButton.swift */,
 				7121A1362C3A6C7C0056DB8B /* CustomAlertViewController.swift */,
 				2D4EE3842C3D6E6B00E3E95B /* CustomProgressView.swift */,
+				2D4EE38A2C3D9FD900E3E95B /* CustomDatePicker.swift */,
 				7121A13F2C3AB9EE0056DB8B /* JobDetailInfoView.swift */,
 			);
 			path = UIComponents;
@@ -286,6 +291,7 @@
 				71E3C4112C243BDD0026C4DD /* getClassName.swift */,
 				7121A13D2C3A98E10056DB8B /* LabelFactory.swift */,
 				7121A14A2C3B09800056DB8B /* setImage.swift */,
+				2D4EE3882C3D9EA400E3E95B /* getKrDate.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -411,6 +417,7 @@
 				71D7E6EF2C2FF48800C54EA7 /* TNTabBarItem.swift in Sources */,
 				7121A13E2C3A98E10056DB8B /* LabelFactory.swift in Sources */,
 				71E3C3CD2C22BAF40026C4DD /* AppDelegate.swift in Sources */,
+				2D4EE38B2C3D9FD900E3E95B /* CustomDatePicker.swift in Sources */,
 				71461ED42C3811E8002A6999 /* ViewController+.swift in Sources */,
 				71E3C4122C243BDD0026C4DD /* getClassName.swift in Sources */,
 				71D7E6F12C2FFB5800C54EA7 /* CALayer+.swift in Sources */,
@@ -421,6 +428,7 @@
 				7121A14B2C3B09800056DB8B /* setImage.swift in Sources */,
 				2D4EE3852C3D6E6B00E3E95B /* CustomProgressView.swift in Sources */,
 				7121A1332C396FB40056DB8B /* CustomButton.swift in Sources */,
+				2D4EE3892C3D9EA400E3E95B /* getKrDate.swift in Sources */,
 				71461ED62C38150C002A6999 /* UILabel+.swift in Sources */,
 				71D7E6ED2C2FF42500C54EA7 /* TNTabBarController.swift in Sources */,
 				7121A1492C3B08360056DB8B /* JobDetailModel.swift in Sources */,

--- a/Terning-iOS/Terning-iOS/Resource/Extension/Foundation+/Date+.swift
+++ b/Terning-iOS/Terning-iOS/Resource/Extension/Foundation+/Date+.swift
@@ -1,5 +1,5 @@
 //
-//  getKrDate.swift
+//  Date+.swift
 //  Terning-iOS
 //
 //  Created by 정민지 on 7/10/24.

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomDatePicker.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomDatePicker.swift
@@ -57,39 +57,42 @@ extension CustomDatePicker: UIPickerViewDelegate {
         return 40
     }
     
-    public func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
+    public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        let containerView: UIView
+        let label: UILabel
+        
+        if let view = view, let reusedLabel = view.subviews.first as? UILabel {
+            containerView = view
+            label = reusedLabel
+        } else {
+            containerView = UIView()
+            label = UILabel()
+            label.textAlignment = .center
+            containerView.addSubview(label)
+            
+            label.snp.makeConstraints {
+                $0.centerY.equalToSuperview()
+                if component == 0 {
+                    $0.trailing.equalToSuperview().inset(15)
+                } else {
+                    $0.leading.equalToSuperview().inset(26)
+                }
+            }
+        }
+        
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .right
         paragraphStyle.tailIndent = 45
         
-        var label: String
-        label = (component == 0) ? "\(years[row])년" : "\(months[row])월"
+        let text = (component == 0) ? "\(years[row])년" : "\(months[row])월"
         
-        return NSAttributedString(string: label, attributes: [
+        let attributedString = NSAttributedString(string: text, attributes: [
             NSAttributedString.Key.paragraphStyle: paragraphStyle,
             NSAttributedString.Key.font: UIFont.title3,
             NSAttributedString.Key.foregroundColor: UIColor.grey500
         ])
-    }
-
-    public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
-        let containerView = UIView()
         
-        var label = UILabel()
-        label.textAlignment = .center
-        
-        label.text = (component == 0) ? "\(years[row])년" : "\(months[row])월"
-        
-        containerView.addSubview(label)
-        
-        label.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            if component == 0 {
-                $0.trailing.equalToSuperview().inset(15)
-            } else {
-                $0.leading.equalToSuperview().inset(26)
-            }
-        }
+        label.attributedText = attributedString
         
         return containerView
     }
@@ -108,7 +111,7 @@ extension CustomDatePicker {
         self.dataSource = self
         self.delegate = self
     }
-
+    
     /// 한국 날짜로 현재 년도와 달을 초기 화면에 뜨는 년도와 달로 설정
     private func setSelectedRow() {
         let (currentYear, currentMonth) = Date().getCurrentKrYearAndMonth()

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomDatePicker.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomDatePicker.swift
@@ -63,11 +63,7 @@ extension CustomDatePicker: UIPickerViewDelegate {
         paragraphStyle.tailIndent = 45
         
         var label: String
-        if component == 0 {
-            label = "\(years[row])년"
-        } else {
-            label = "\(months[row])월"
-        }
+        label = (component == 0) ? "\(years[row])년" : "\(months[row])월"
         
         return NSAttributedString(string: label, attributes: [
             NSAttributedString.Key.paragraphStyle: paragraphStyle,

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomDatePicker.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomDatePicker.swift
@@ -21,9 +21,7 @@ public final class CustomDatePicker: UIPickerView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        self.dataSource = self
-        self.delegate = self
-        
+        setDelegate()
         setSelectedRow()
     }
     
@@ -81,23 +79,19 @@ extension CustomDatePicker: UIPickerViewDelegate {
     public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
         let containerView = UIView()
         
-        let label = UILabel()
+        var label = UILabel()
         label.textAlignment = .center
         
-        if component == 0 {
-            label.text = "\(years[row])년"
-        } else {
-            label.text  = "\(months[row])월"
-        }
+        label.text = (component == 0) ? "\(years[row])년" : "\(months[row])월"
         
         containerView.addSubview(label)
         
-        label.snp.makeConstraints { make in
-            make.centerY.equalToSuperview()
+        label.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
             if component == 0 {
-                make.trailing.equalToSuperview().inset(15)
+                $0.trailing.equalToSuperview().inset(15)
             } else {
-                make.leading.equalToSuperview().inset(26)
+                $0.leading.equalToSuperview().inset(26)
             }
         }
         
@@ -113,8 +107,13 @@ extension CustomDatePicker: UIPickerViewDelegate {
 
 // MARK: - Methods
 
-/// 한국 날짜로 현재 년도와 달을 초기 화면에 뜨는 년도와 달로 설정
 extension CustomDatePicker {
+    private func setDelegate() {
+        self.dataSource = self
+        self.delegate = self
+    }
+
+    /// 한국 날짜로 현재 년도와 달을 초기 화면에 뜨는 년도와 달로 설정
     private func setSelectedRow() {
         let (currentYear, currentMonth) = Date().getCurrentKrYearAndMonth()
         
@@ -122,9 +121,6 @@ extension CustomDatePicker {
            let initialMonthIndex = months.firstIndex(of: currentMonth) {
             self.selectRow(initialYearIndex, inComponent: 0, animated: false)
             self.selectRow(initialMonthIndex, inComponent: 1, animated: false)
-            
-            pickerView(self, didSelectRow: initialYearIndex, inComponent: 0)
-            pickerView(self, didSelectRow: initialMonthIndex, inComponent: 1)
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomDatePicker.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomDatePicker.swift
@@ -1,0 +1,130 @@
+//
+//  CustomDatePicker.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/10/24.
+//
+
+import UIKit
+
+public final class CustomDatePicker: UIPickerView {
+    
+    // MARK: - Properties
+    
+    private let years = Array(2023...2025)
+    private let months = Array(1...12)
+    
+    var onDateSelected: ((Int, Int) -> Void)?
+    
+    // MARK: - initialization
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.dataSource = self
+        self.delegate = self
+        
+        setSelectedRow()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UIPickerViewDataSource
+
+extension CustomDatePicker: UIPickerViewDataSource {
+    public func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 2
+    }
+    
+    public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        if component == 0 {
+            return years.count
+        } else {
+            return months.count
+        }
+    }
+}
+
+// MARK: - UIPickerViewDelegate
+
+extension CustomDatePicker: UIPickerViewDelegate {
+    public func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+        return 100
+    }
+    
+    public func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+        return 40
+    }
+    
+    public func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .right
+        paragraphStyle.tailIndent = 45
+        
+        var label: String
+        if component == 0 {
+            label = "\(years[row])년"
+        } else {
+            label = "\(months[row])월"
+        }
+        
+        return NSAttributedString(string: label, attributes: [
+            NSAttributedString.Key.paragraphStyle: paragraphStyle,
+            NSAttributedString.Key.font: UIFont.title3,
+            NSAttributedString.Key.foregroundColor: UIColor.grey500
+        ])
+    }
+
+    public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        let containerView = UIView()
+        
+        let label = UILabel()
+        label.textAlignment = .center
+        
+        if component == 0 {
+            label.text = "\(years[row])년"
+        } else {
+            label.text  = "\(months[row])월"
+        }
+        
+        containerView.addSubview(label)
+        
+        label.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            if component == 0 {
+                make.trailing.equalToSuperview().inset(15)
+            } else {
+                make.leading.equalToSuperview().inset(26)
+            }
+        }
+        
+        return containerView
+    }
+    
+    public func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        let selectedYear = years[pickerView.selectedRow(inComponent: 0)]
+        let selectedMonth = months[pickerView.selectedRow(inComponent: 1)]
+        onDateSelected?(selectedYear, selectedMonth)
+    }
+}
+
+// MARK: - Methods
+
+/// 한국 날짜로 현재 년도와 달을 초기 화면에 뜨는 년도와 달로 설정
+extension CustomDatePicker {
+    private func setSelectedRow() {
+        let (currentYear, currentMonth) = Date().getCurrentKrYearAndMonth()
+        
+        if let initialYearIndex = years.firstIndex(of: currentYear),
+           let initialMonthIndex = months.firstIndex(of: currentMonth) {
+            self.selectRow(initialYearIndex, inComponent: 0, animated: false)
+            self.selectRow(initialMonthIndex, inComponent: 1, animated: false)
+            
+            pickerView(self, didSelectRow: initialYearIndex, inComponent: 0)
+            pickerView(self, didSelectRow: initialMonthIndex, inComponent: 1)
+        }
+    }
+}

--- a/Terning-iOS/Terning-iOS/Resource/Utils/getKrDate.swift
+++ b/Terning-iOS/Terning-iOS/Resource/Utils/getKrDate.swift
@@ -1,0 +1,19 @@
+//
+//  getKrDate.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/10/24.
+//
+
+import Foundation
+
+public extension Date {
+    func getCurrentKrYearAndMonth() -> (year: Int, month: Int) {
+        let currentDate = self
+        var calendar = Calendar.current
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+        let currentYear = calendar.component(.year, from: currentDate)
+        let currentMonth = calendar.component(.month, from: currentDate)
+        return (year: currentYear, month: currentMonth)
+    }
+}


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #20 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
```swift
public extension Date {
    func getCurrentKrYearAndMonth() -> (year: Int, month: Int) {
        let currentDate = self
        var calendar = Calendar.current
        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
        let currentYear = calendar.component(.year, from: currentDate)
        let currentMonth = calendar.component(.month, from: currentDate)
        return (year: currentYear, month: currentMonth)
    }
}
```
```swift
extension CustomDatePicker {
    private func setSelectedRow() {
        let (currentYear, currentMonth) = Date().getCurrentKrYearAndMonth()
        
        if let initialYearIndex = years.firstIndex(of: currentYear),
           let initialMonthIndex = months.firstIndex(of: currentMonth) {
            self.selectRow(initialYearIndex, inComponent: 0, animated: false)
            self.selectRow(initialMonthIndex, inComponent: 1, animated: false)
            
            pickerView(self, didSelectRow: initialYearIndex, inComponent: 0)
            pickerView(self, didSelectRow: initialMonthIndex, inComponent: 1)
        }
    }
}
```
한국 날짜로 현재 년도와 달을 초기 화면에 뜨는 년도와 달로 설정해 놓았고, 한국 년도, 달 구할수 있는 Utils 구현해 놓았습니다!

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->
```swift
public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
    let containerView: UIView
    let label: UILabel
    
    if let view = view, let reusedLabel = view.subviews.first as? UILabel {
        containerView = view
        label = reusedLabel
    } else {
        containerView = UIView()
        label = UILabel()
        label.textAlignment = .center
        containerView.addSubview(label)
        
        label.snp.makeConstraints {
            $0.centerY.equalToSuperview()
            if component == 0 {
                $0.trailing.equalToSuperview().inset(15)
            } else {
                $0.leading.equalToSuperview().inset(26)
            }
        }
    }
    
    let paragraphStyle = NSMutableParagraphStyle()
    paragraphStyle.alignment = .right
    paragraphStyle.tailIndent = 45
    
    let text = (component == 0) ? "\(years[row])년" : "\(months[row])월"
    
    let attributedString = NSAttributedString(string: text, attributes: [
        NSAttributedString.Key.paragraphStyle: paragraphStyle,
        NSAttributedString.Key.font: UIFont.title3,
        NSAttributedString.Key.foregroundColor: UIColor.grey500
    ])
    
    label.attributedText = attributedString
    
    return containerView
}
```
곡률 차이를 줄여 디자인과 최대한 비슷하게 구현 했습니다.
곡률을 최소로 유지하려면 구성 요소 너비(`paragraphStyle.tailIndent`)를 꼬리 들여쓰기(`widthForComponent`)의 약 두 배로 설정해야 합니다.

위 코드를 사용해서 두개의 component 위치를 지정와 간격을 수정할 수 있도록 했습니다.

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->
https://github.com/teamterning/Terning-iOS/assets/109158284/9ccd07e8-9b7e-48f9-a7e3-542b1d48ae99


<br/>

# 🖌️ Reference
1. https://stackoverflow.com/questions/19825688/ios-7-uipickerview-non-selected-row-curvature-modification-multiple-components
2. https://thingjin.tistory.com/entry/iOS-UIPickerView-%EC%BB%A4%EC%8A%A4%ED%85%80-%EA%B5%AC%ED%98%84-UIKit


<br/>
