### PR TITLE
[Feat] #14 - Custom NavigatoinBar를 구현 했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
+++ b/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2D4EE3872C3D7CB200E3E95B /* CustomOnboardingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3862C3D7CB200E3E95B /* CustomOnboardingButton.swift */; };
 		2D4EE3852C3D6E6B00E3E95B /* CustomProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3842C3D6E6B00E3E95B /* CustomProgressView.swift */; };
+		2D4EE3872C3D7CB200E3E95B /* CustomOnboardingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3862C3D7CB200E3E95B /* CustomOnboardingButton.swift */; };
 		2D4EE3892C3D9EA400E3E95B /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3882C3D9EA400E3E95B /* Date+.swift */; };
 		2D4EE38B2C3D9FD900E3E95B /* CustomDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE38A2C3D9FD900E3E95B /* CustomDatePicker.swift */; };
 		7121A1332C396FB40056DB8B /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1322C396FB40056DB8B /* CustomButton.swift */; };
@@ -23,6 +23,7 @@
 		7121A1492C3B08360056DB8B /* JobDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1482C3B08360056DB8B /* JobDetailModel.swift */; };
 		7121A14B2C3B09800056DB8B /* setImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A14A2C3B09800056DB8B /* setImage.swift */; };
 		7121A1512C3B09E10056DB8B /* Result+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1502C3B09E10056DB8B /* Result+.swift */; };
+		7121A1532C3DE3680056DB8B /* CustomNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1522C3DE3680056DB8B /* CustomNavigationBar.swift */; };
 		71461EB52C37043A002A6999 /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 71461EAC2C370439002A6999 /* Pretendard-Light.otf */; };
 		71461EB72C37043A002A6999 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 71461EAE2C370439002A6999 /* Pretendard-Medium.otf */; };
 		71461EB92C37043A002A6999 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 71461EB02C37043A002A6999 /* Pretendard-SemiBold.otf */; };
@@ -50,8 +51,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		2D4EE3862C3D7CB200E3E95B /* CustomOnboardingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomOnboardingButton.swift; sourceTree = "<group>"; };
 		2D4EE3842C3D6E6B00E3E95B /* CustomProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomProgressView.swift; sourceTree = "<group>"; };
+		2D4EE3862C3D7CB200E3E95B /* CustomOnboardingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomOnboardingButton.swift; sourceTree = "<group>"; };
 		2D4EE3882C3D9EA400E3E95B /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		2D4EE38A2C3D9FD900E3E95B /* CustomDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDatePicker.swift; sourceTree = "<group>"; };
 		7121A1322C396FB40056DB8B /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
@@ -64,6 +65,7 @@
 		7121A1482C3B08360056DB8B /* JobDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobDetailModel.swift; sourceTree = "<group>"; };
 		7121A14A2C3B09800056DB8B /* setImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = setImage.swift; sourceTree = "<group>"; };
 		7121A1502C3B09E10056DB8B /* Result+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+.swift"; sourceTree = "<group>"; };
+		7121A1522C3DE3680056DB8B /* CustomNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationBar.swift; sourceTree = "<group>"; };
 		71461EAC2C370439002A6999 /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
 		71461EAE2C370439002A6999 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		71461EB02C37043A002A6999 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				7121A1362C3A6C7C0056DB8B /* CustomAlertViewController.swift */,
 				2D4EE3842C3D6E6B00E3E95B /* CustomProgressView.swift */,
 				2D4EE38A2C3D9FD900E3E95B /* CustomDatePicker.swift */,
+				7121A1522C3DE3680056DB8B /* CustomNavigationBar.swift */,
 				7121A13F2C3AB9EE0056DB8B /* JobDetailInfoView.swift */,
 			);
 			path = UIComponents;
@@ -432,6 +435,7 @@
 				2D4EE3852C3D6E6B00E3E95B /* CustomProgressView.swift in Sources */,
 				7121A1332C396FB40056DB8B /* CustomButton.swift in Sources */,
 				2D4EE3892C3D9EA400E3E95B /* Date+.swift in Sources */,
+				7121A1532C3DE3680056DB8B /* CustomNavigationBar.swift in Sources */,
 				71461ED62C38150C002A6999 /* UILabel+.swift in Sources */,
 				71D7E6ED2C2FF42500C54EA7 /* TNTabBarController.swift in Sources */,
 				7121A1492C3B08360056DB8B /* JobDetailModel.swift in Sources */,

--- a/Terning-iOS/Terning-iOS/Resource/Extension/UIKit+/ViewController+.swift
+++ b/Terning-iOS/Terning-iOS/Resource/Extension/UIKit+/ViewController+.swift
@@ -34,4 +34,13 @@ public extension UIViewController {
         let generator = UIImpactFeedbackGenerator(style: degree)
         generator.impactOccurred()
     }
+    
+    /// 뷰 컨트롤러가 네비게이션 스택에 있으면 pop 하고, 나머지는  dismiss 합니다.
+    func popOrDismissViewController(animated: Bool = true) {
+        if let navigationController = self.navigationController, navigationController.viewControllers.contains(self) {
+            navigationController.popViewController(animated: animated)
+        } else if self.presentingViewController != nil {
+            self.dismiss(animated: animated)
+        }
+    }
 }

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomAlertViewController.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomAlertViewController.swift
@@ -445,7 +445,7 @@ extension CustomAlertViewController {
     
     /// 중앙 버튼의 텍스트 변경
     @discardableResult
-    public func setLeftButtonTitle(_ title: NSAttributedString) -> Self {
+    public func setCenterButtonTitle(_ title: NSAttributedString) -> Self {
         self.centerButton.changeTitle(attributedString: title)
         return self
     }

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomAlertViewController.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomAlertViewController.swift
@@ -185,7 +185,7 @@ final class CustomAlertViewController: UIViewController {
 
 extension CustomAlertViewController {
     private func setUI() {
-        view.backgroundColor = .black.withAlphaComponent(0.3)
+        view.backgroundColor = .terningBlack.withAlphaComponent(0.3)
         alertView.backgroundColor = .white
         alertView.layer.cornerRadius = 20
     }

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomButton.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomButton.swift
@@ -54,6 +54,8 @@ extension CustomButton {
     /// 버튼의 Title 변경
     @discardableResult
     public func setTitle(title: String) -> Self {
+        self.title = title
+        
         self.setAttributedTitle(
             NSAttributedString(
                 string: title,

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomNavigationBar.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomNavigationBar.swift
@@ -1,0 +1,149 @@
+//
+//  CustomNavigationBar.swift
+//  Terning-iOS
+//
+//  Created by 이명진 on 7/10/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+@frozen
+enum NavigationBarType {
+    case leftButton // 뒤로가기 버튼
+    case centerTitleWithLeftButton // 뒤로가기 버튼 + 중앙 타이틀
+}
+
+final class CustomNavigationBar: UIView {
+    
+    // MARK: - Properties
+    
+    private var naviType: NavigationBarType!
+    private var viewController: UIViewController?
+    private var leftButtonClosure: (() -> Void)?
+    private var isShadow: Bool = true
+    
+    // MARK: - UI Components
+    
+    private lazy var centerTitleLabel = createTitleLabel()
+    
+    let leftButton = UIButton().then {
+        $0.setImage(UIImage(resource: .icBackArrow), for: .normal)
+    }
+    
+    // MARK: - Life Cycles
+    
+    init(_ viewController: UIViewController, type: NavigationBarType, isShadow: Bool = true) {
+        super.init(frame: .zero)
+        
+        self.viewController = viewController
+        self.isShadow = isShadow
+        self.setUI(type)
+        self.setLayout(type)
+        self.setAddTarget(type)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+// MARK: - UI & Layout
+
+extension CustomNavigationBar {
+    private func setUI(_ type: NavigationBarType) {
+            addSubviews(leftButton)
+            
+            self.backgroundColor = .white
+            
+            if isShadow {
+                self.layer.applyShadow(alpha: 0.15, y: 3, blur: 4, spread: 0)
+            }
+            
+            if type == .centerTitleWithLeftButton {
+                addSubview(centerTitleLabel)
+            }
+        }
+    
+    private func setLayout(_ type: NavigationBarType) {
+        
+        leftButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(20)
+            $0.width.height.equalTo(32)
+        }
+        
+        if type == .centerTitleWithLeftButton {
+            centerTitleLabel.snp.makeConstraints {
+                $0.center.equalToSuperview()
+            }
+        }
+    }
+    
+    private func createTitleLabel() -> UILabel {
+        return UILabel().then {
+            $0.font = .title2
+            $0.textColor = .black
+        }
+    }
+}
+
+// MARK: - Custom methods
+
+extension CustomNavigationBar {
+    func hideNaviBar(_ isHidden: Bool) {
+        UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut) {
+            [
+                self.centerTitleLabel,
+                self.leftButton
+            ].forEach { $0.alpha = isHidden ? 0 : 1 }
+        }
+    }
+    
+    /// 내비게이션의 title을 세팅합니다.
+    func setTitle(_ title: String) -> Self {
+        self.centerTitleLabel.text = title
+        return self
+    }
+    
+    /// 기존 뒤로가기 버튼의 Action을 수정하고 싶을때 사용합니다.
+    @discardableResult
+    func resetLeftButtonAction(_ closure: (() -> Void)? = nil, _ type: NavigationBarType) -> Self {
+        self.leftButtonClosure = closure
+        self.leftButton.removeTarget(self, action: nil, for: .touchUpInside)
+        if closure != nil {
+            self.leftButton.addTarget(self, action: #selector(leftButtonDidTap), for: .touchUpInside)
+        } else {
+            self.setAddTarget(type)
+        }
+        return self
+    }
+    
+    /// 내비게이션의 title의 font와 textColor를 수정합니다.
+    func updateTitleFontAndColor(font: UIFont, color: UIColor) -> Self {
+        centerTitleLabel.font = font
+        centerTitleLabel.textColor = color
+        return self
+    }
+    
+    private func setAddTarget(_ type: NavigationBarType) {
+        if type == .centerTitleWithLeftButton {
+            leftButton.addTarget(self, action: #selector(popToPreviousVC), for: .touchUpInside)
+        }
+    }
+}
+
+extension CustomNavigationBar {
+    @objc
+    private func popToPreviousVC() {
+        self.viewController?.popOrDismissViewController()
+    }
+    
+    @objc
+    private func leftButtonDidTap() {
+        self.leftButtonClosure?()
+    }
+}

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomNavigationBar.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomNavigationBar.swift
@@ -60,7 +60,7 @@ extension CustomNavigationBar {
             self.backgroundColor = .white
             
             if isShadow {
-                self.layer.applyShadow(alpha: 0.15, y: 3, blur: 4, spread: 0)
+                self.layer.applyShadow(color: .terningBlack, alpha: 0.15, y: 3, blur: 4, spread: 0)
             }
             
             if type == .centerTitleWithLeftButton {
@@ -86,7 +86,7 @@ extension CustomNavigationBar {
     private func createTitleLabel() -> UILabel {
         return UILabel().then {
             $0.font = .title2
-            $0.textColor = .black
+            $0.textColor = .terningBlack
         }
     }
 }
@@ -130,9 +130,7 @@ extension CustomNavigationBar {
     }
     
     private func setAddTarget(_ type: NavigationBarType) {
-        if type == .centerTitleWithLeftButton {
-            leftButton.addTarget(self, action: #selector(popToPreviousVC), for: .touchUpInside)
-        }
+        leftButton.addTarget(self, action: #selector(popToPreviousVC), for: .touchUpInside)
     }
 }
 

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/JobDetailInfoView.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/JobDetailInfoView.swift
@@ -42,7 +42,7 @@ final class JobDetailInfoView: UIView {
 
 extension JobDetailInfoView {
     private func setUI(title: String, description: String) {
-        self.backgroundColor = .white
+        self.backgroundColor = .clear
         self.titleLabel.text = title
         self.descriptionLabel.text = description
     }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #14

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->

- CustomNavigationBar 구현

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

## 1. 커스텀 네비게이션 바 사용

- 아래처럼 프로퍼티 만들고, 레이아웃 평소처럼 똑같이 만들어 주면 됩니다.
생성자에 isShadow 프로퍼티를 사용해서 그림자를 없앨 수 있습니다.

```swift
private lazy var naviBar = CustomNavigationBar(self, type: .centerTitleWithLeftButton).setTitle("Shodow 있는 내비")
```

<img src = "https://github.com/teamterning/Terning-iOS/assets/88179341/b7dccd5f-7163-439e-8ace-681f5a6e35d2" width = "50%" height = "50%">

- 뒤로 가기 버튼을 누르면 자동으로 pop되는 코드를 심어놨고, `resetLeftButtonAction` 함수를 통해 커스텀 이벤트도 구현 할 수 있습니다.

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

- 아래는 그림자 없는 버전 입니다 ~

<img src = "https://github.com/teamterning/Terning-iOS/assets/88179341/f154e177-f852-4070-844a-122f2a8f5ef7" width = "50%" height = "50%">

<br/>
