### PR TITLE
[Feat] #8 - 공고 상세 페이지 구현했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
+++ b/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
@@ -21,6 +21,21 @@
 		2D4EE3E82C400D6900E3E95B /* OnboardingPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3E72C400D6900E3E95B /* OnboardingPageViewController.swift */; };
 		2D4EE3EA2C400ECB00E3E95B /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3E92C400ECB00E3E95B /* OnboardingViewController.swift */; };
 		2D4EE3ED2C4020DC00E3E95B /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4EE3EC2C4020DC00E3E95B /* OnboardingViewModel.swift */; };
+		2DC61EF32C4075E3009F991F /* JobDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EF22C4075E3009F991F /* JobDetailViewController.swift */; };
+		2DC61EF52C4075EB009F991F /* MainInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EF42C4075EB009F991F /* MainInfoTableViewCell.swift */; };
+		2DC61EF72C4075F3009F991F /* JobDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EF62C4075F3009F991F /* JobDetailViewModel.swift */; };
+		2DC61EF92C407E65009F991F /* JobDetailTableViewHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EF82C407E65009F991F /* JobDetailTableViewHeaderCell.swift */; };
+		2DC61EFD2C40823C009F991F /* CompanyInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EFC2C40823C009F991F /* CompanyInfoTableViewCell.swift */; };
+		2DC61EFF2C40824A009F991F /* SummaryInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EFE2C40824A009F991F /* SummaryInfoTableViewCell.swift */; };
+		2DC61F012C40825D009F991F /* DetailInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61F002C40825D009F991F /* DetailInfoTableViewCell.swift */; };
+		2DC61F032C4087B4009F991F /* JobSummaryInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61F022C4087B4009F991F /* JobSummaryInfoView.swift */; };
+		2DC61F052C40926D009F991F /* JobDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61F042C40926D009F991F /* JobDetailView.swift */; };
+		2DC61F072C4145CD009F991F /* CustomScrapButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61F062C4145CD009F991F /* CustomScrapButton.swift */; };
+		2DC61F0A2C418D09009F991F /* BottomInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61F092C418D09009F991F /* BottomInfoModel.swift */; };
+		2DC61F0C2C418D20009F991F /* DetailInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61F0B2C418D20009F991F /* DetailInfoModel.swift */; };
+		2DC61F0E2C418D35009F991F /* SummaryInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61F0D2C418D35009F991F /* SummaryInfoModel.swift */; };
+		2DC61F102C418D44009F991F /* CompanyInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61F0F2C418D44009F991F /* CompanyInfoModel.swift */; };
+		2DC61F122C418D5A009F991F /* MainInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61F112C418D5A009F991F /* MainInfoModel.swift */; };
 		7121A1332C396FB40056DB8B /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1322C396FB40056DB8B /* CustomButton.swift */; };
 		7121A1352C39CCF60056DB8B /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1342C39CCF60056DB8B /* UIButton+.swift */; };
 		7121A1372C3A6C7C0056DB8B /* CustomAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7121A1362C3A6C7C0056DB8B /* CustomAlertViewController.swift */; };
@@ -94,6 +109,21 @@
 		2D4EE3E72C400D6900E3E95B /* OnboardingPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPageViewController.swift; sourceTree = "<group>"; };
 		2D4EE3E92C400ECB00E3E95B /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		2D4EE3EC2C4020DC00E3E95B /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
+		2DC61EF22C4075E3009F991F /* JobDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobDetailViewController.swift; sourceTree = "<group>"; };
+		2DC61EF42C4075EB009F991F /* MainInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainInfoTableViewCell.swift; sourceTree = "<group>"; };
+		2DC61EF62C4075F3009F991F /* JobDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobDetailViewModel.swift; sourceTree = "<group>"; };
+		2DC61EF82C407E65009F991F /* JobDetailTableViewHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobDetailTableViewHeaderCell.swift; sourceTree = "<group>"; };
+		2DC61EFC2C40823C009F991F /* CompanyInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanyInfoTableViewCell.swift; sourceTree = "<group>"; };
+		2DC61EFE2C40824A009F991F /* SummaryInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryInfoTableViewCell.swift; sourceTree = "<group>"; };
+		2DC61F002C40825D009F991F /* DetailInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailInfoTableViewCell.swift; sourceTree = "<group>"; };
+		2DC61F022C4087B4009F991F /* JobSummaryInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobSummaryInfoView.swift; sourceTree = "<group>"; };
+		2DC61F042C40926D009F991F /* JobDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobDetailView.swift; sourceTree = "<group>"; };
+		2DC61F062C4145CD009F991F /* CustomScrapButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomScrapButton.swift; sourceTree = "<group>"; };
+		2DC61F092C418D09009F991F /* BottomInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomInfoModel.swift; sourceTree = "<group>"; };
+		2DC61F0B2C418D20009F991F /* DetailInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailInfoModel.swift; sourceTree = "<group>"; };
+		2DC61F0D2C418D35009F991F /* SummaryInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryInfoModel.swift; sourceTree = "<group>"; };
+		2DC61F0F2C418D44009F991F /* CompanyInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanyInfoModel.swift; sourceTree = "<group>"; };
+		2DC61F112C418D5A009F991F /* MainInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainInfoModel.swift; sourceTree = "<group>"; };
 		7121A1322C396FB40056DB8B /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		7121A1342C39CCF60056DB8B /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		7121A1362C3A6C7C0056DB8B /* CustomAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertViewController.swift; sourceTree = "<group>"; };
@@ -260,17 +290,66 @@
 			path = ViewController;
 			sourceTree = "<group>";
 		};
+		2DC61EEE2C40759F009F991F /* JobDetail */ = {
+			isa = PBXGroup;
+			children = (
+				2DC61EEF2C4075AF009F991F /* ViewController */,
+				2DC61EF02C4075BE009F991F /* View */,
+				2DC61F082C418807009F991F /* Cell */,
+				2DC61EF12C4075C9009F991F /* ViewModel */,
+			);
+			path = JobDetail;
+			sourceTree = "<group>";
+		};
+		2DC61EEF2C4075AF009F991F /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				2DC61EF22C4075E3009F991F /* JobDetailViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		2DC61EF02C4075BE009F991F /* View */ = {
+			isa = PBXGroup;
+			children = (
+				2DC61F042C40926D009F991F /* JobDetailView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		2DC61EF12C4075C9009F991F /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				2DC61EF62C4075F3009F991F /* JobDetailViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		2DC61F082C418807009F991F /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				2DC61EF82C407E65009F991F /* JobDetailTableViewHeaderCell.swift */,
+				2DC61EF42C4075EB009F991F /* MainInfoTableViewCell.swift */,
+				2DC61EFC2C40823C009F991F /* CompanyInfoTableViewCell.swift */,
+				2DC61EFE2C40824A009F991F /* SummaryInfoTableViewCell.swift */,
+				2DC61F002C40825D009F991F /* DetailInfoTableViewCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 		7121A1312C396F980056DB8B /* UIComponents */ = {
 			isa = PBXGroup;
 			children = (
 				7121A1412C3AE99D0056DB8B /* Cell */,
 				7121A1322C396FB40056DB8B /* CustomButton.swift */,
+				2DC61F062C4145CD009F991F /* CustomScrapButton.swift */,
 				2D4EE3862C3D7CB200E3E95B /* CustomOnboardingButton.swift */,
 				7121A1362C3A6C7C0056DB8B /* CustomAlertViewController.swift */,
 				2D4EE3842C3D6E6B00E3E95B /* CustomProgressView.swift */,
 				2D4EE38A2C3D9FD900E3E95B /* CustomDatePicker.swift */,
 				7121A1522C3DE3680056DB8B /* CustomNavigationBar.swift */,
 				7121A13F2C3AB9EE0056DB8B /* JobDetailInfoView.swift */,
+				2DC61F022C4087B4009F991F /* JobSummaryInfoView.swift */,
 			);
 			path = UIComponents;
 			sourceTree = "<group>";
@@ -295,6 +374,11 @@
 			isa = PBXGroup;
 			children = (
 				7121A1482C3B08360056DB8B /* JobDetailModel.swift */,
+				2DC61F112C418D5A009F991F /* MainInfoModel.swift */,
+				2DC61F0F2C418D44009F991F /* CompanyInfoModel.swift */,
+				2DC61F0D2C418D35009F991F /* SummaryInfoModel.swift */,
+				2DC61F0B2C418D20009F991F /* DetailInfoModel.swift */,
+				2DC61F092C418D09009F991F /* BottomInfoModel.swift */,
 			);
 			path = Announcements;
 			sourceTree = "<group>";
@@ -402,6 +486,7 @@
 		71E3C3E82C241C020026C4DD /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				2DC61EEE2C40759F009F991F /* JobDetail */,
 				2D4EE3D82C3F520000E3E95B /* Onboarding */,
 				2D4EE3A02C3E787200E3E95B /* ProfileView */,
 				2D4EE3922C3DD5A000E3E95B /* WelcomeView */,
@@ -672,7 +757,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2DC61F012C40825D009F991F /* DetailInfoTableViewCell.swift in Sources */,
+				2DC61F102C418D44009F991F /* CompanyInfoModel.swift in Sources */,
 				B871D7332C3EC148008D78C2 /* IsScrapInfoViewCell.swift in Sources */,
+				2DC61F0A2C418D09009F991F /* BottomInfoModel.swift in Sources */,
 				2D4EE3962C3DD5CB00E3E95B /* WelcomeViewController.swift in Sources */,
 				7121A1572C3EA4C10056DB8B /* LoadingIndicator.swift in Sources */,
 				71E3C40F2C243B510026C4DD /* UIView+.swift in Sources */,
@@ -682,6 +770,7 @@
 				7121A1432C3AE9C20056DB8B /* PaletteCell.swift in Sources */,
 				2D4EE3E62C3FFF9200E3E95B /* OnboardingView.swift in Sources */,
 				71D7E6EF2C2FF48800C54EA7 /* TNTabBarItem.swift in Sources */,
+				2DC61EFD2C40823C009F991F /* CompanyInfoTableViewCell.swift in Sources */,
 				7121A13E2C3A98E10056DB8B /* LabelFactory.swift in Sources */,
 				2D4EE3AB2C3E854E00E3E95B /* ValidationMessage.swift in Sources */,
 				71E3C3CD2C22BAF40026C4DD /* AppDelegate.swift in Sources */,
@@ -690,6 +779,7 @@
 				71461ED42C3811E8002A6999 /* ViewController+.swift in Sources */,
 				71E3C4122C243BDD0026C4DD /* getClassName.swift in Sources */,
 				71D7E6F12C2FFB5800C54EA7 /* CALayer+.swift in Sources */,
+				2DC61EFF2C40824A009F991F /* SummaryInfoTableViewCell.swift in Sources */,
 				B871D7352C3ECF37008D78C2 /* ScrapedAndDeadlineModel.swift in Sources */,
 				2D4EE3A22C3E788200E3E95B /* ProfileViewModel.swift in Sources */,
 				7121A1512C3B09E10056DB8B /* Result+.swift in Sources */,
@@ -697,11 +787,16 @@
 				7121A1462C3B07AA0056DB8B /* BaseResponse.swift in Sources */,
 				B8C5DB6E2C3F353D00865B1A /* InavailableFilterView.swift in Sources */,
 				7121A1352C39CCF60056DB8B /* UIButton+.swift in Sources */,
+				2DC61F122C418D5A009F991F /* MainInfoModel.swift in Sources */,
 				7121A1552C3EA01F0056DB8B /* Toast.swift in Sources */,
+				2DC61F0E2C418D35009F991F /* SummaryInfoModel.swift in Sources */,
 				71E3C3CF2C22BAF40026C4DD /* SceneDelegate.swift in Sources */,
+				2DC61EF52C4075EB009F991F /* MainInfoTableViewCell.swift in Sources */,
+				2DC61F072C4145CD009F991F /* CustomScrapButton.swift in Sources */,
 				2D4EE3E82C400D6900E3E95B /* OnboardingPageViewController.swift in Sources */,
 				2D4EE3EA2C400ECB00E3E95B /* OnboardingViewController.swift in Sources */,
 				B871D7392C3F1A49008D78C2 /* CheckDeadlineCell.swift in Sources */,
+				2DC61F032C4087B4009F991F /* JobSummaryInfoView.swift in Sources */,
 				B871D7372C3EF87B008D78C2 /* NonJobCardCell.swift in Sources */,
 				B871D72F2C3E909F008D78C2 /* DecorationCell.swift in Sources */,
 				B871D7202C3E877B008D78C2 /* HomeViewController.swift in Sources */,
@@ -709,16 +804,21 @@
 				B871D7292C3E8E46008D78C2 /* JobCardScrapedCell.swift in Sources */,
 				B871D71E2C3E8771008D78C2 /* HomeView.swift in Sources */,
 				B871D72B2C3E8ED7008D78C2 /* SortButtonCell.swift in Sources */,
+				2DC61EF32C4075E3009F991F /* JobDetailViewController.swift in Sources */,
+				2DC61F0C2C418D20009F991F /* DetailInfoModel.swift in Sources */,
 				2D4EE3852C3D6E6B00E3E95B /* CustomProgressView.swift in Sources */,
+				2DC61EF92C407E65009F991F /* JobDetailTableViewHeaderCell.swift in Sources */,
 				B8C5DB732C3F39C700865B1A /* FilteringSettingViewController.swift in Sources */,
 				2D4EE3A62C3E78A200E3E95B /* ProfileViewController.swift in Sources */,
 				7121A1332C396FB40056DB8B /* CustomButton.swift in Sources */,
+				2DC61EF72C4075F3009F991F /* JobDetailViewModel.swift in Sources */,
 				B871D7232C3E8836008D78C2 /* JobCardModel.swift in Sources */,
 				B871D7312C3E9118008D78C2 /* NonScrapInfoCells.swift in Sources */,
 				2D4EE3892C3D9EA400E3E95B /* Date+.swift in Sources */,
 				7121A1532C3DE3680056DB8B /* CustomNavigationBar.swift in Sources */,
 				71461ED62C38150C002A6999 /* UILabel+.swift in Sources */,
 				71D7E6ED2C2FF42500C54EA7 /* TNTabBarController.swift in Sources */,
+				2DC61F052C40926D009F991F /* JobDetailView.swift in Sources */,
 				7121A1492C3B08360056DB8B /* JobDetailModel.swift in Sources */,
 				2D4EE3ED2C4020DC00E3E95B /* OnboardingViewModel.swift in Sources */,
 				7121A1372C3A6C7C0056DB8B /* CustomAlertViewController.swift in Sources */,

--- a/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap.imageset/Contents.json
+++ b/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "ios_ic_28_scrap.svg",
+      "filename" : "Property 1=default.svg",
       "idiom" : "universal",
       "scale" : "1x"
     },

--- a/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap.imageset/Property 1=default.svg
+++ b/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap.imageset/Property 1=default.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 3H8C6.89543 3 6 3.89543 6 5V21L11.3753 16.6998C11.7405 16.4076 12.2595 16.4076 12.6247 16.6998L18 21V5C18 3.89543 17.1046 3 16 3Z" stroke="#ADADAD" stroke-width="2.04" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap.imageset/ios_ic_28_scrap.svg
+++ b/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap.imageset/ios_ic_28_scrap.svg
@@ -1,3 +1,0 @@
-<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M18 5H10C8.89543 5 8 5.89543 8 7V23L13.3753 18.6998C13.7405 18.4076 14.2595 18.4076 14.6247 18.6998L20 23V7C20 5.89543 19.1046 5 18 5Z" stroke="#ADADAD" stroke-width="2.04" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap_fill.imageset/Contents.json
+++ b/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap_fill.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "Vector 1.svg",
+      "filename" : "Property 1=active.svg",
       "idiom" : "universal",
       "scale" : "1x"
     },

--- a/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap_fill.imageset/Property 1=active.svg
+++ b/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap_fill.imageset/Property 1=active.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 3H8C6.89543 3 6 3.89543 6 5V21L11.3753 16.6998C11.7405 16.4076 12.2595 16.4076 12.6247 16.6998L18 21V5C18 3.89543 17.1046 3 16 3Z" fill="#1EAC61" stroke="#1EAC61" stroke-width="2.04" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap_fill.imageset/Vector 1.svg
+++ b/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Icons/ic_scrap_fill.imageset/Vector 1.svg
@@ -1,4 +1,0 @@
-<svg width="12" height="18" viewBox="0 0 12 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M6 12L1 16.5V0.5H11V16H10.5L6 12Z" fill="#666666"/>
-<path d="M1 0V0.5M1 0.5V16.5L6 12L10.5 16H11V0.5H1Z" stroke="#666666"/>
-</svg>

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomScrapButton.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomScrapButton.swift
@@ -20,6 +20,7 @@ class CustomScrapButton: UIButton {
         super.init(frame: frame)
         
         setUI()
+        setButtonAction()
     }
     
     required init?(coder: NSCoder) {
@@ -30,15 +31,18 @@ class CustomScrapButton: UIButton {
 // MARK: - UI & Layout
 
 extension CustomScrapButton {
-    private func  setUI() {
+    private func setUI() {
         self.setImage(deselectedImage, for: .normal)
-        self.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
     }
 }
 
 // MARK: - Methods
 
 extension CustomScrapButton {
+    private func setButtonAction() {
+        self.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+    }
+    
    func updateImage() {
         if self.isSelected {
             self.setImage(selectedImage, for: .normal)

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomScrapButton.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomScrapButton.swift
@@ -1,0 +1,59 @@
+//
+//  CustomScrapButton.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/12/24.
+//
+
+import UIKit
+
+class CustomScrapButton: UIButton {
+    
+    // MARK: - Properties
+    
+    private let selectedImage = UIImage(named: "ic_scrap_fill")
+    private let deselectedImage = UIImage(named: "ic_scrap")
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension CustomScrapButton {
+    private func  setUI() {
+        self.setImage(deselectedImage, for: .normal)
+        self.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+    }
+}
+
+// MARK: - Methods
+
+extension CustomScrapButton {
+   func updateImage() {
+        if self.isSelected {
+            self.setImage(selectedImage, for: .normal)
+        } else {
+            self.setImage(deselectedImage, for: .normal)
+        }
+    }
+}
+
+// MARK: - @objc func
+
+extension CustomScrapButton {
+    @objc
+    private func buttonTapped() {
+        self.isSelected.toggle()
+        self.updateImage()
+    }
+}

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/JobDetailInfoView.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/JobDetailInfoView.swift
@@ -14,15 +14,21 @@ final class JobDetailInfoView: UIView {
     
     // MARK: - UI Components
     
-    private let titleLabel = UILabel().then {
-        $0.font = .body2
-        $0.textColor = .grey350
-    }
+    private let titleLabel = LabelFactory.build(
+        text: " ",
+        font: .body2,
+        textColor: .grey350,
+        lineSpacing: 1.2,
+        characterSpacing: 0.002
+    )
     
-    private let descriptionLabel = UILabel().then {
-        $0.font = .body3
-        $0.textColor = .grey500
-    }
+    private let descriptionLabel = LabelFactory.build(
+        text: " ",
+        font: .body3,
+        textColor: .grey500,
+        lineSpacing: 1.2,
+        characterSpacing: 0.002
+    )
     
     // MARK: - Init
     
@@ -51,7 +57,7 @@ extension JobDetailInfoView {
         self.addSubviews(titleLabel, descriptionLabel)
         
         titleLabel.snp.makeConstraints {
-            $0.top.leading.equalToSuperview()
+            $0.verticalEdges.leading.equalToSuperview()
         }
         
         descriptionLabel.snp.makeConstraints {
@@ -68,6 +74,13 @@ extension JobDetailInfoView {
     @discardableResult
     func setDescriptionText(description: String) -> Self {
         self.descriptionLabel.text = description
+        return self
+    }
+    
+    @discardableResult
+    func setTitleTextColor(titleColor: UIColor, descriptionColor: UIColor) -> Self {
+        self.titleLabel.textColor = titleColor
+        self.descriptionLabel.textColor = descriptionColor
         return self
     }
 }

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/JobSummaryInfoView.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/JobSummaryInfoView.swift
@@ -1,0 +1,131 @@
+//
+//  JobSummaryInfoView.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/12/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class JobSummaryInfoView: UIView {
+    
+    // MARK: - Properties
+    
+    private var descriptionLabels: [UILabel] = []
+    
+    // MARK: - UI Components
+    
+    private let imageView = UIImageView().then {
+        $0.image = .icLightbulb
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    private let titleLabel = LabelFactory.build(
+        text: "자격요건",
+        font: .button2,
+        textColor: .grey500,
+        textAlignment: .left,
+        lineSpacing: 1.2,
+        characterSpacing: 0.002
+    )
+    
+    // MARK: - Init
+    
+    init(image: UIImage, title: String, descriptions: [String]) {
+        
+        super.init(frame: .zero)
+        
+        self.setUI(
+            image: image,
+            title: title,
+            descriptions: descriptions
+        )
+        self.setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension JobSummaryInfoView {
+    private func setUI(image: UIImage, title: String, descriptions: [String]) {
+        self.backgroundColor = .clear
+        self.imageView.image = image
+        self.titleLabel.text = title
+        self.descriptionLabels = descriptions.map {
+            let label = LabelFactory.build(
+                text: $0,
+                font: .body5,
+                textColor: .grey400,
+                textAlignment: .left,
+                lineSpacing: 1.2,
+                characterSpacing: 0.002
+            )
+            return label
+        }
+    }
+    
+    private func setLayout() {
+        self.addSubviews(imageView, titleLabel)
+        
+        imageView.snp.makeConstraints {
+            $0.top.leading.equalToSuperview()
+            $0.width.height.equalTo(20)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.equalTo(imageView.snp.trailing).offset(3)
+            $0.width.equalTo(60)
+        }
+        
+        var previousLabel: UILabel? = nil
+        for (index, label) in descriptionLabels.enumerated() {
+            self.addSubview(label)
+            label.snp.makeConstraints {
+                if let previous = previousLabel {
+                    $0.top.equalTo(previous.snp.bottom).offset(5)
+                } else {
+                    $0.top.equalToSuperview()
+                }
+                $0.leading.equalTo(titleLabel.snp.trailing).offset(17)
+                $0.trailing.equalToSuperview()
+                if index == descriptionLabels.count - 1 {
+                    $0.bottom.equalToSuperview()
+                }
+            }
+            previousLabel = label
+        }
+    }
+}
+
+// MARK: - Methods
+
+extension JobSummaryInfoView {
+    @discardableResult
+    func setDescriptionText(descriptions: [String]) -> Self {
+        descriptionLabels.forEach { $0.removeFromSuperview() }
+
+        self.descriptionLabels = descriptions.map {
+            let label = LabelFactory.build(
+                text: $0,
+                font: .body4,
+                textColor: .grey400,
+                textAlignment: .left,
+                lineSpacing: 1.5,
+                characterSpacing: 0.002
+            )
+            label.numberOfLines = 0
+            return label
+        }
+        setLayout()
+        
+        return self
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Data/Announcements/BottomInfoModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Announcements/BottomInfoModel.swift
@@ -1,0 +1,14 @@
+//
+//  BottomInfoModel.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/13/24.
+//
+
+import Foundation
+
+struct BottomInfoModel {
+    let url: String?
+    let isScrap: Bool
+    let scrapCount: Int
+}

--- a/Terning-iOS/Terning-iOS/Source/Data/Announcements/CompanyInfoModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Announcements/CompanyInfoModel.swift
@@ -1,0 +1,14 @@
+//
+//  CompanyInfoModel.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/13/24.
+//
+
+import Foundation
+
+struct CompanyInfoModel {
+    let company: String
+    let companyCategory: String
+    let companyImage: String?
+}

--- a/Terning-iOS/Terning-iOS/Source/Data/Announcements/DetailInfoModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Announcements/DetailInfoModel.swift
@@ -1,0 +1,12 @@
+//
+//  DetailInfoModel.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/13/24.
+//
+
+import Foundation
+
+struct DetailInfoModel {
+    let detail: String
+}

--- a/Terning-iOS/Terning-iOS/Source/Data/Announcements/JobDetailModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Announcements/JobDetailModel.swift
@@ -22,4 +22,5 @@ struct JobDetailModel: Codable {
     let detail: String
     let url: String
     let isScrap: Bool
+    let scrapCount: Int
 }

--- a/Terning-iOS/Terning-iOS/Source/Data/Announcements/MainInfoModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Announcements/MainInfoModel.swift
@@ -1,0 +1,17 @@
+//
+//  MainInfoModel.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/13/24.
+//
+
+import Foundation
+
+struct MainInfoModel {
+    let dDay: String
+    let title: String
+    let deadline: String
+    let workingPeriod: String
+    let startDate: String
+    let viewCount: Int
+}

--- a/Terning-iOS/Terning-iOS/Source/Data/Announcements/SummaryInfoModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Announcements/SummaryInfoModel.swift
@@ -1,0 +1,13 @@
+//
+//  SummaryInfoModel.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/13/24.
+//
+
+import Foundation
+
+struct SummaryInfoModel {
+    let qualification: [String]
+    let jobType: [String]
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringSettingViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringSettingViewController.swift
@@ -45,7 +45,7 @@ extension FilteringSettingViewController {
     @objc
     func gradeButton1DidTap() {
         print("1학년")
-        
+
 
         if rootView.gradeButton1.isSelected {
             rootView.gradeButton1.backgroundColor = .clear

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/CompanyInfoTableViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/CompanyInfoTableViewCell.swift
@@ -17,8 +17,7 @@ final class CompanyInfoTableViewCell: UITableViewCell {
         $0.contentMode = .scaleAspectFill
         $0.layer.cornerRadius = 30
         $0.layer.masksToBounds = true 
-        $0.layer.borderColor = UIColor.terningMain.cgColor
-        $0.layer.borderWidth = 1
+        $0.makeBorder(width: 2, color: .terningMain)
     }
     
     private let companyNameLabel = LabelFactory.build(

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/CompanyInfoTableViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/CompanyInfoTableViewCell.swift
@@ -1,0 +1,91 @@
+//
+//  CompanyInfoTableViewCell.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/12/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class CompanyInfoTableViewCell: UITableViewCell {
+    
+    // MARK: - UI Components
+    
+    private let companyImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.layer.cornerRadius = 30
+        $0.layer.masksToBounds = true 
+        $0.layer.borderColor = UIColor.terningMain.cgColor
+        $0.layer.borderWidth = 1
+    }
+    
+    private let companyNameLabel = LabelFactory.build(
+        text: "회사명",
+        font: .title4,
+        textAlignment: .left
+    ).then {
+        $0.numberOfLines = 2
+    }
+    
+    private let companyTypeLabel = LabelFactory.build(
+        text: "스타트업",
+        font: .body4,
+        textColor: .grey300,
+        textAlignment: .left,
+        lineSpacing: 1.5,
+        characterSpacing: 0.002
+    )
+    
+    // MARK: - Init
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension CompanyInfoTableViewCell {
+    private func setUI() {
+        self.addSubviews(companyImageView, companyNameLabel, companyTypeLabel)
+    }
+    
+    private func setLayout() {
+        companyImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(16)
+            $0.leading.bottom.equalToSuperview().inset(20)
+            $0.height.width.equalTo(60)
+        }
+        
+        companyNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(27)
+            $0.leading.equalTo(companyImageView.snp.trailing).offset(12)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+        
+        companyTypeLabel.snp.makeConstraints {
+            $0.top.equalTo(companyNameLabel.snp.bottom).offset(1)
+            $0.leading.equalTo(companyImageView.snp.trailing).offset(12)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+    }
+}
+
+// MARK: - Methods
+
+extension CompanyInfoTableViewCell {
+    func configure(with companyInfo: CompanyInfoModel) {
+        companyImageView.setImage(with: companyInfo.companyImage ?? "placeholder_image", placeholder: "placeholder_image")
+        companyNameLabel.text = companyInfo.company
+        companyTypeLabel.text = companyInfo.companyCategory
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/DetailInfoTableViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/DetailInfoTableViewCell.swift
@@ -1,0 +1,61 @@
+//
+//  DetailInfoTableViewCell.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/12/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class DetailInfoTableViewCell: UITableViewCell {
+    
+    // MARK: - UI Components
+    
+    private let datailDescriptionLabel = LabelFactory.build(
+        text: "상세 정보입니다.",
+        font: .detail1,
+        textColor: .grey400,
+        textAlignment: .left,
+        lineSpacing: 1.2,
+        characterSpacing: 0.002
+    ).then {
+        $0.numberOfLines = 0
+    }
+    
+    // MARK: - Init
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension DetailInfoTableViewCell {
+    private func setUI() {
+        self.addSubview(datailDescriptionLabel)
+    }
+    private func setLayout() {
+        datailDescriptionLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(16)
+            $0.horizontalEdges.bottom.equalToSuperview().inset(20)
+        }
+    }
+}
+
+// MARK: - Methods
+
+extension DetailInfoTableViewCell {
+    func configure(with detailInfo: DetailInfoModel) {
+        datailDescriptionLabel.text = detailInfo.detail
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/JobDetailTableViewHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/JobDetailTableViewHeaderCell.swift
@@ -1,0 +1,60 @@
+//
+//  JobDetailTableViewHeaderCell.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/12/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class JobDetailTableViewHeaderView: UITableViewHeaderFooterView {
+    
+    // MARK: - UI Components
+    
+    private let titleLabel = LabelFactory.build(
+        text: "기업 정보",
+        font: .title4,
+        textColor: .terningMain,
+        textAlignment: .left
+    )
+    
+    // MARK: - Init
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension JobDetailTableViewHeaderView {
+    private func setUI() {
+        contentView.backgroundColor = .terningSelect
+        contentView.addSubview(titleLabel)
+    }
+    
+    private func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(6)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(5)
+        }
+    }
+}
+
+// MARK: - Public Methods
+
+extension JobDetailTableViewHeaderView {
+    public func setTitle(_ title: String) {
+        titleLabel.text = title
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/MainInfoTableViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/MainInfoTableViewCell.swift
@@ -15,9 +15,11 @@ final class MainInfoTableViewCell: UITableViewCell {
     // MARK: - UI Components
     
     private let dDayDivView = UIView().then {
-        $0.layer.cornerRadius = 10
-        $0.layer.borderColor = UIColor.terningMain.cgColor
-        $0.layer.borderWidth = 1
+        $0.makeBorder(
+            width: 1,
+            color: .terningMain,
+            cornerRadius: 10
+        )
     }
     
     private let dDayLabel = LabelFactory.build(
@@ -87,24 +89,21 @@ final class MainInfoTableViewCell: UITableViewCell {
 
 extension MainInfoTableViewCell {
     private func setUI() {
-        [dDayDivView,
-         titleLabel,
-         divView,
-         viewsTitleLabel,
-         viewsLabel
-        ].forEach {
-            self.addSubview($0)
-        }
+        self.addSubviews(
+            dDayDivView,
+            titleLabel,
+            divView,
+            viewsTitleLabel,
+            viewsLabel
+        )
         
         dDayDivView.addSubview(dDayLabel)
         
-        [
+        divView.addSubviews(
             deadlineInfoView,
             workPeriodInfoView,
             workStartInfoView
-        ].forEach {
-            divView.addSubviews($0)
-        }
+        )
     }
     
     private func setLayout() {

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/MainInfoTableViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/MainInfoTableViewCell.swift
@@ -1,0 +1,181 @@
+//
+//  MainInfoTableViewCell.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/12/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class MainInfoTableViewCell: UITableViewCell {
+    
+    // MARK: - UI Components
+    
+    private let dDayDivView = UIView().then {
+        $0.layer.cornerRadius = 10
+        $0.layer.borderColor = UIColor.terningMain.cgColor
+        $0.layer.borderWidth = 1
+    }
+    
+    private let dDayLabel = LabelFactory.build(
+        text: "D-3",
+        font: .body0,
+        textColor: .terningMain,
+        lineSpacing: 1.0,
+        characterSpacing: 0.002
+    )
+    
+    private let titleLabel = LabelFactory.build(
+        text: "[SomeOne] 콘텐츠 마케터 대학생 인턴 채용",
+        font: .title2,
+        textAlignment: .left
+    ).then {
+        $0.numberOfLines = 2
+    }
+    
+    private let divView = UIView().then {
+        $0.layer.cornerRadius = 5
+        $0.layer.borderColor = UIColor.terningMain.cgColor
+        $0.layer.borderWidth = 1
+    }
+
+    private let deadlineInfoView = JobDetailInfoView(
+        title: "서류 마감",
+        description: "2024년 7월 23일"
+    )
+    
+    private let workPeriodInfoView = JobDetailInfoView(
+        title: "근무 기간",
+        description: "2개월"
+    )
+    
+    private let workStartInfoView = JobDetailInfoView(
+        title: "근무 시작",
+        description: "2024년 8월"
+    )
+    
+    private let viewsTitleLabel = LabelFactory.build(
+        text: "조회수",
+        font: .detail3,
+        textColor: .grey400
+    )
+    
+    private let viewsLabel = LabelFactory.build(
+        text: "3,219회",
+        font: .button4,
+        textColor: .grey400
+    )
+    
+    // MARK: - Init
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension MainInfoTableViewCell {
+    private func setUI() {
+        [dDayDivView,
+         titleLabel,
+         divView,
+         viewsTitleLabel,
+         viewsLabel
+        ].forEach {
+            self.addSubview($0)
+        }
+        
+        dDayDivView.addSubview(dDayLabel)
+        
+        [
+            deadlineInfoView,
+            workPeriodInfoView,
+            workStartInfoView
+        ].forEach {
+            divView.addSubviews($0)
+        }
+    }
+    
+    private func setLayout() {
+        dDayDivView.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().inset(20)
+        }
+        
+        dDayLabel.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview()
+            $0.leading.equalToSuperview().inset(10)
+            $0.trailing.equalToSuperview().inset(11)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(dDayDivView.snp.bottom).offset(8)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        divView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        deadlineInfoView.snp.makeConstraints {
+            $0.top.equalTo(divView.snp.top).inset(16)
+            $0.leading.equalTo(divView.snp.leading).inset(16)
+            $0.height.equalTo(18)
+        }
+        
+        workPeriodInfoView.snp.makeConstraints {
+            $0.top.equalTo(deadlineInfoView.snp.bottom).offset(5)
+            $0.leading.equalTo(divView.snp.leading).inset(16)
+            $0.height.equalTo(18)
+        }
+        
+        workStartInfoView.snp.makeConstraints {
+            $0.top.equalTo(workPeriodInfoView.snp.bottom).offset(5)
+            $0.leading.equalTo(divView.snp.leading).inset(16)
+            $0.height.equalTo(18)
+            $0.bottom.equalTo(divView.snp.bottom).inset(16)
+        }
+        
+        viewsLabel.snp.makeConstraints {
+            $0.top.equalTo(divView.snp.bottom).offset(8)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(14)
+        }
+        
+        viewsTitleLabel.snp.makeConstraints {
+            $0.centerY.equalTo(viewsLabel.snp.centerY)
+            $0.trailing.equalTo(viewsLabel.snp.leading).offset(-3)
+        }
+    }
+}
+
+// MARK: - Methods
+
+extension MainInfoTableViewCell {
+    func configure(with mainInfo: MainInfoModel) {
+        if let dDayInt = Int(mainInfo.dDay) {
+            dDayLabel.text = "D-\(dDayInt)"
+        } else {
+            dDayLabel.text = mainInfo.dDay
+        }
+        
+        titleLabel.text = mainInfo.title
+        
+        deadlineInfoView.setDescriptionText(description: mainInfo.deadline)
+        workPeriodInfoView.setDescriptionText(description: mainInfo.workingPeriod)
+        workStartInfoView.setDescriptionText(description: mainInfo.startDate)
+        
+        viewsLabel.text = "\(mainInfo.viewCount)회"
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/SummaryInfoTableViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/SummaryInfoTableViewCell.swift
@@ -1,0 +1,68 @@
+//
+//  SummaryInfoTableViewCell.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/12/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class SummaryInfoTableViewCell: UITableViewCell {
+    
+    // MARK: - UI Components
+    
+    private let qualificationLabel = JobSummaryInfoView(
+        image: .icLightbulb,
+        title: "자격요건",
+        descriptions: ["졸업 예정자", "휴학생 가능"]
+    )
+    
+    private let dutyLabel = JobSummaryInfoView(
+        image: .icBag,
+        title: "직무",
+        descriptions: ["그래픽디자인", "UX/UI/GUI 디자인"]
+    )
+    
+    // MARK: - Init
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension SummaryInfoTableViewCell {
+    private func setUI() {
+        self.addSubviews(qualificationLabel, dutyLabel)
+    }
+    private func setLayout() {
+        qualificationLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(16)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        dutyLabel.snp.makeConstraints {
+            $0.top.equalTo(qualificationLabel.snp.bottom).offset(14)
+            $0.horizontalEdges.bottom.equalToSuperview().inset(20)
+        }
+    }
+}
+
+// MARK: - Methods
+
+extension SummaryInfoTableViewCell {
+    func configure(with summaryInfo: SummaryInfoModel) {
+        qualificationLabel.setDescriptionText(descriptions: summaryInfo.qualification)
+        dutyLabel.setDescriptionText(descriptions: summaryInfo.jobType)
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/View/JobDetailView.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/View/JobDetailView.swift
@@ -1,0 +1,153 @@
+//
+//  JobDetailView.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/12/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class JobDetailView: UIView {
+    
+    // MARK: - Properties
+    
+    var mainInfo: MainInfoModel?
+    var companyInfo: CompanyInfoModel?
+    var summaryInfo: SummaryInfoModel?
+    var detailInfo: DetailInfoModel?
+    private var url: String?
+    
+    // MARK: - UI Components
+    
+    let tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .grouped)
+        tableView.separatorStyle = .none
+        tableView.showsVerticalScrollIndicator = false
+        return tableView
+    }()
+
+    private let bottomView = UIView().then {
+        $0.backgroundColor = .white
+        $0.layer.shadowColor = UIColor.black.cgColor
+        $0.layer.shadowOpacity = 0.05
+        $0.layer.shadowOffset = CGSize(width: 0, height: -4)
+        $0.layer.shadowRadius = 2
+        $0.layer.masksToBounds = false
+    }
+    
+    private let companyImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.layer.cornerRadius = 30
+        $0.layer.borderColor = UIColor.terningMain.cgColor
+        $0.layer.borderWidth = 1
+        $0.backgroundColor = .red
+    }
+    
+    private var scrapLabel = LabelFactory.build(
+        text: "512회",
+        font: .detail3,
+        textColor: .grey400,
+        lineSpacing: 1.2,
+        characterSpacing: 0.002
+    )
+    
+    private var scrapButton = CustomScrapButton()
+    
+    private var goSiteButton = CustomButton(title: "지원 사이트로 이동하기")
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setLayout()
+        setButtonAction()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension JobDetailView {
+    private func setUI() {
+        tableView.register(MainInfoTableViewCell.self, forCellReuseIdentifier: MainInfoTableViewCell.className)
+        tableView.register(CompanyInfoTableViewCell.self, forCellReuseIdentifier: CompanyInfoTableViewCell.className)
+        tableView.register(SummaryInfoTableViewCell.self, forCellReuseIdentifier: SummaryInfoTableViewCell.className)
+        tableView.register(DetailInfoTableViewCell.self, forCellReuseIdentifier: DetailInfoTableViewCell.className)
+        tableView.register(JobDetailTableViewHeaderView.self, forHeaderFooterViewReuseIdentifier: JobDetailTableViewHeaderView.className)
+        tableView.backgroundColor = .white
+    }
+    
+    private func setLayout() {
+        self.addSubviews(tableView, bottomView)
+        
+        bottomView.addSubviews(scrapLabel, scrapButton, goSiteButton)
+        
+        tableView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(68)
+        }
+        
+        bottomView.snp.makeConstraints {
+            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.height.equalTo(68)
+        }
+        
+        scrapLabel.snp.makeConstraints {
+            $0.bottom.equalTo(bottomView.snp.bottom).inset(9)
+            $0.leading.equalTo(bottomView.snp.leading).inset(21)
+            $0.width.equalTo(45)
+        }
+        
+        scrapButton.snp.makeConstraints {
+            $0.top.equalTo(bottomView.snp.top).inset(16)
+            $0.centerX.equalTo(scrapLabel.snp.centerX)
+        }
+        
+        goSiteButton.snp.makeConstraints {
+            $0.top.equalTo(bottomView.snp.top).inset(10)
+            $0.leading.equalTo(scrapLabel.snp.trailing).offset(12)
+            $0.trailing.equalTo(bottomView.snp.trailing).inset(20)
+            $0.height.equalTo(48)
+        }
+    }
+}
+
+// MARK: - Methods
+extension JobDetailView {
+    private func setButtonAction() {
+        goSiteButton.addTarget(self, action: #selector(goToUrl), for: .touchUpInside)
+    }
+}
+
+// MARK: - Public Methods
+
+extension JobDetailView {
+    func setUrl(_ url: String?) {
+        self.url = url
+    }
+    
+    func setScrapped(_ isScrap: Bool) {
+        scrapButton.isSelected = isScrap
+        scrapButton.updateImage()
+    }
+    
+    func setScrapCount(_ count: Int) {
+        scrapLabel.text = "\(count)회"
+    }
+}
+
+// MARK: - @objc func
+
+extension JobDetailView {
+    @objc private func goToUrl() {
+        guard let urlString = url, let url = URL(string: urlString) else { return }
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/ViewController/JobDetailViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/ViewController/JobDetailViewController.swift
@@ -1,0 +1,218 @@
+//
+//  JobDetailViewController.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/12/24.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+import SnapKit
+
+@frozen
+enum JobDetailInfoType: Int, CaseIterable {
+    case mainInfo = 0
+    case companyInfo = 1
+    case summaryInfo = 2
+    case detailInfo = 3
+}
+
+final class JobDetailViewController: UIViewController {
+    
+    // MARK: - UI Components
+    
+    private let jobDetailView = JobDetailView()
+    private let viewModel = JobDetailViewModel()
+    private let disposeBag = DisposeBag()
+    private var jobDetail: JobDetailModel?
+    
+    // MARK: - View Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        
+        setUI()
+        setLayout()
+        setDelegate()
+        bindViewModel()
+    }
+}
+
+// MARK: - UI & Layout
+
+extension JobDetailViewController {
+    private func setUI() {
+        view.addSubview(jobDetailView)
+    }
+    
+    private func setLayout() {
+        jobDetailView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+}
+
+// MARK: - Methods
+
+extension JobDetailViewController {
+    private func setDelegate() {
+        jobDetailView.tableView.dataSource = self
+        jobDetailView.tableView.delegate = self
+    }
+}
+
+// MARK: - Bind
+
+extension JobDetailViewController {
+    private func bindViewModel() {
+        let input = JobDetailViewModel.Input(fetchJobDetail: Observable.just(()))
+        
+        let output = viewModel.transform(input)
+        
+        output.mainInfo
+            .drive(onNext: { [weak self] mainInfo in
+                self?.jobDetailView.mainInfo = mainInfo
+            })
+            .disposed(by: disposeBag)
+        
+        output.companyInfo
+            .drive(onNext: { [weak self] companyInfo in
+                self?.jobDetailView.companyInfo = companyInfo
+            })
+            .disposed(by: disposeBag)
+        
+        output.summaryInfo
+            .drive(onNext: { [weak self] summaryInfo in
+                self?.jobDetailView.summaryInfo = summaryInfo
+            })
+            .disposed(by: disposeBag)
+        
+        output.detailInfo
+            .drive(onNext: { [weak self] detailInfo in
+                self?.jobDetailView.detailInfo = detailInfo
+            })
+            .disposed(by: disposeBag)
+        
+        output.bottomInfo
+            .drive(onNext: { [weak self] bottomInfo in
+                self?.jobDetailView.setUrl(bottomInfo.url)
+                self?.jobDetailView.setScrapped(bottomInfo.isScrap)
+                self?.jobDetailView.setScrapCount(bottomInfo.scrapCount)
+            })
+            .disposed(by: disposeBag)
+        
+        Observable.combineLatest(
+            output.mainInfo.asObservable(),
+            output.companyInfo.asObservable(),
+            output.summaryInfo.asObservable(),
+            output.detailInfo.asObservable()
+        ).subscribe(onNext: { [weak self] _, _, _, _ in
+            self?.jobDetailView.tableView.reloadData()
+        }).disposed(by: disposeBag)
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension JobDetailViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return JobDetailInfoType.allCases.count
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let sectionType = JobDetailInfoType(rawValue: indexPath.section) else {
+            return UITableViewCell()
+        }
+        
+        switch sectionType {
+        case .mainInfo:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: MainInfoTableViewCell.className, for: indexPath) as? MainInfoTableViewCell,
+                  let mainInfo = jobDetailView.mainInfo else {
+                return UITableViewCell()
+            }
+            cell.configure(with: mainInfo)
+            cell.selectionStyle = .none
+            return cell
+        case .companyInfo:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: CompanyInfoTableViewCell.className, for: indexPath) as? CompanyInfoTableViewCell,
+                  let companyInfo = jobDetailView.companyInfo else {
+                return UITableViewCell()
+            }
+            cell.configure(with: companyInfo)
+            cell.selectionStyle = .none
+            return cell
+        case .summaryInfo:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: SummaryInfoTableViewCell.className, for: indexPath) as? SummaryInfoTableViewCell,
+                  let summaryInfo = jobDetailView.summaryInfo else {
+                return UITableViewCell()
+            }
+            cell.configure(with: summaryInfo)
+            cell.selectionStyle = .none
+            return cell
+        case .detailInfo:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: DetailInfoTableViewCell.className, for: indexPath) as? DetailInfoTableViewCell,
+                  let detailInfo = jobDetailView.detailInfo else {
+                return UITableViewCell()
+            }
+            cell.configure(with: detailInfo)
+            cell.selectionStyle = .none
+            return cell
+        }
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension JobDetailViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let sectionType = JobDetailInfoType(rawValue: section) else { return nil }
+        
+        switch sectionType {
+        case .companyInfo, .summaryInfo, .detailInfo:
+            guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: JobDetailTableViewHeaderView.className) as? JobDetailTableViewHeaderView else {
+                return nil
+            }
+            
+            let title: String
+            switch sectionType {
+            case .companyInfo:
+                title = "기업 정보"
+            case .summaryInfo:
+                title = "공고 요약"
+            case .detailInfo:
+                title = "상세 정보"
+            default:
+                return nil
+            }
+            headerView.setTitle(title)
+            return headerView
+        default:
+            return nil
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 0
+    }
+    
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return UIView(frame: CGRect.zero)
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/ViewModel/JobDetailViewModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/ViewModel/JobDetailViewModel.swift
@@ -1,0 +1,162 @@
+//
+//  JobDetailViewModel.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/12/24.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+final class JobDetailViewModel {
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - Input
+    
+    struct Input {
+        let fetchJobDetail: Observable<Void>
+    }
+    
+    // MARK: - Output
+    
+    struct Output {
+        let mainInfo: Driver<MainInfoModel>
+        let companyInfo: Driver<CompanyInfoModel>
+        let summaryInfo: Driver<SummaryInfoModel>
+        let detailInfo: Driver<DetailInfoModel>
+        let bottomInfo: Driver<BottomInfoModel>
+    }
+    
+    // MARK: - Transform
+    
+    func transform(_ input: Input) -> Output {
+        let jobDetail = input.fetchJobDetail
+            .flatMapLatest { _ in
+                self.fetchJobDetailFromServer()
+                    .asDriver(onErrorJustReturn: JobDetailModel(
+                        dDay: "",
+                        title: "",
+                        deadline: "",
+                        workingPeriod: "",
+                        startDate: "",
+                        viewCount: 0,
+                        company: "",
+                        companyCategory: "",
+                        companyImage: "",
+                        qualification: "",
+                        jobType: "",
+                        detail: "",
+                        url: "",
+                        isScrap: false,
+                        scrapCount: 500
+                    ))
+            }
+            .share(replay: 1)
+        
+        let mainInfo = jobDetail.map {
+            MainInfoModel(
+                dDay: $0.dDay,
+                title: $0.title,
+                deadline: $0.deadline,
+                workingPeriod: $0.workingPeriod,
+                startDate: $0.startDate,
+                viewCount: $0.viewCount
+            )
+        }.asDriver(
+            onErrorJustReturn: MainInfoModel(
+                dDay: "",
+                title: "",
+                deadline: "",
+                workingPeriod: "",
+                startDate: "",
+                viewCount: 0
+            )
+        )
+        
+        let companyInfo = jobDetail.map {
+            CompanyInfoModel(
+                company: $0.company,
+                companyCategory: $0.companyCategory,
+                companyImage: $0.companyImage
+            )
+        }.asDriver(
+            onErrorJustReturn: CompanyInfoModel(
+                company: "",
+                companyCategory: "",
+                companyImage: nil
+            )
+        )
+        
+        let summaryInfo = jobDetail.map {
+            SummaryInfoModel(
+                qualification: $0.qualification.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) },
+                jobType: $0.jobType.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+            )
+        }.asDriver(
+            onErrorJustReturn: SummaryInfoModel(
+                qualification: [],
+                jobType: []
+            )
+        )
+        
+        let detailInfo = jobDetail.map {
+            DetailInfoModel(
+                detail: $0.detail
+            )
+        }.asDriver(
+            onErrorJustReturn: DetailInfoModel(
+                detail: ""
+            )
+        )
+        
+        let bottomInfo = jobDetail.map {
+            BottomInfoModel(
+                url: $0.url,
+                isScrap: $0.isScrap,
+                scrapCount: $0.scrapCount
+            )
+        }.asDriver(
+            onErrorJustReturn: BottomInfoModel(
+                url: "",
+                isScrap: false,
+                scrapCount: 0
+            )
+        )
+        
+        return Output(
+            mainInfo: mainInfo,
+            companyInfo: companyInfo,
+            summaryInfo: summaryInfo,
+            detailInfo: detailInfo,
+            bottomInfo: bottomInfo
+        )
+    }
+}
+
+// MARK: - Methods
+
+extension JobDetailViewModel {
+    
+    private func fetchJobDetailFromServer() -> Observable<JobDetailModel> {
+        let dummyData = JobDetailModel(
+            dDay: "D-4",
+            title: "[SomeOne] 성공성공성공성공",
+            deadline: "2024년 7월 23일",
+            workingPeriod: "2개월",
+            startDate: "2024년 8월",
+            viewCount: 3423,
+            company: "모니모니",
+            companyCategory: "스타트업",
+            companyImage: "https://images.unsplash.com/photo-1573865526739-10659fec78a5?q=80&w=2815&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+            qualification: "졸업 예정자, 휴학생 가능, 헐, ㅋ",
+            jobType: "그래픽 디자인, UX/UI/GUI 디자인, 대박, ㅋㅋ",
+            detail: "모니모니의 마케팅 팀은 소비자에게 삶의 솔루션으로서 ‘사랑’을 제시하는 아주 멋진 팀입니다.\n‘사랑’의 가치를 전 세계에 전파하기 위해 마케터는 그 누구보다 넓은 시야를 가져야 합니다. 거시적인 관점과 미시적인 관점을 모두 포괄할 수 있는 통찰력을 바탕으로 나아갑니다.\n데이터에 근거하여 소통합니다. ‘사랑’,  ‘행복’. ‘같이’와 같은 추상적인 가치들을 수치로 가시화하는 아주 재미있는 작업을 함께합니다.",
+            url: "https://github.com/teamterning",
+            isScrap: true,
+            scrapCount: 3423
+        )
+        return Observable.just(dummyData)
+    }
+}


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #8 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->

```swift
extension CustomScrapButton {
   func updateImage() {
        if self.isSelected {
            self.setImage(selectedImage, for: .normal)
        } else {
            self.setImage(deselectedImage, for: .normal)
        }
    }
}
```
작업하면서 CustomScrapButton 컴포넌트를 추가로 제작해 놓았습니다.

```swift
func setScrapped(_ isScrap: Bool) {
        scrapButton.isSelected = isScrap
        scrapButton.updateImage()
    }
```
다른 파일에서 해당 방식으로 위 컴포넌트를 사용할 수 있습니다. 


```swift
extension JobDetailView {
    @objc private func goToUrl() {
        guard let urlString = url, let url = URL(string: urlString) else { return }
        UIApplication.shared.open(url, options: [:], completionHandler: nil)
    }
}
```
지원 사이트로 이동하기 버튼의 경우 사파리로 해당 url을 이동하도록 해놓았습니다. 

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

```swift
@frozen
enum JobDetailInfoType: Int, CaseIterable {
    case mainInfo = 0
    case companyInfo = 1
    case summaryInfo = 2
    case detailInfo = 3
}
```
이렇게 네개의 타입으로 셀을 나누어서 테이블뷰로 상세 페이지를 구성하였습니다. 
딱히 중복되는 내용이 없어 재사용 셀을 쓰는게 별로인가 고민했지만 하나의 뷰로 다루는거보다 데이터 종류마다 다루는 것이 확장성과 유지보수 관점에서 더 쉬울 것 같다고 생각하여 셀을 나누어 구성했습니다.


```swift
    struct Input {
        let fetchJobDetail: Observable<Void>
    }
    
    // MARK: - Output
    
    struct Output {
        let mainInfo: Driver<MainInfoModel>
        let companyInfo: Driver<CompanyInfoModel>
        let summaryInfo: Driver<SummaryInfoModel>
        let detailInfo: Driver<DetailInfoModel>
        let bottomInfo: Driver<BottomInfoModel>
    }
```
뷰모델의 경우 공고 상세 페이지의 모든 데이터가 담겨있는 하나의 리스트를 서버로 부터 통신 받고
각각에 셀에 필요한 데이터로 나누어 바인딩 시켜주었습니다.

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

https://github.com/user-attachments/assets/ed8a8dab-2bad-4948-888b-b93f4a0c9d31


<br/>
