### PR TITLE
[Feat] #37 - 필터링 세팅 뷰 선택된 버튼 일괄 전달 작업 완료했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringSettingView.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringSettingView.swift
@@ -13,8 +13,7 @@ import Then
 class FilteringSettingView: UIView {
     
     // MARK: - UIComponents
-
-    // user  select one's grade
+    
     let gradeSelectionTitle = LabelFactory.build(
         text: "재학 상태를 선택해주세요",
         font: .title3,
@@ -69,7 +68,6 @@ class FilteringSettingView: UIView {
         $0.distribution = .fillEqually
     }
     
-    // user select period
     let periodSelectionTitle = LabelFactory.build(
         text: "희망하는 인턴 근무 기간을 선택해주세요",
         font: .title3,
@@ -120,7 +118,6 @@ class FilteringSettingView: UIView {
     
     var monthPickerView = CustomDatePicker()
     
-    // user select month
     let monthSelectionTitle = LabelFactory.build(
         text: "입사를 계획중인 달을 선택해주세요",
         font: .title3,
@@ -139,6 +136,14 @@ class FilteringSettingView: UIView {
         $0.spacing = 0
         $0.alignment = .leading
     }
+    
+    lazy var saveButton = UIButton().then {
+        $0.setTitle("저장하기", for: .normal)
+        $0.titleLabel?.font = .button0
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = .terningMain
+    }
+    
     // MARK: LifeCycles
     
     override init(frame: CGRect) {
@@ -169,7 +174,8 @@ extension FilteringSettingView {
             titleStack2,
             periodButtonStack,
             titleStack3,
-            monthPickerView
+            monthPickerView,
+            saveButton
         )
     }
     
@@ -232,6 +238,12 @@ extension FilteringSettingView {
         monthPickerView.snp.makeConstraints {
             $0.top.equalTo(titleStack3.snp.bottom).offset(20)
             $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        saveButton.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(52)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(52)
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringSettingViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringSettingViewController.swift
@@ -39,8 +39,9 @@ class FilteringSettingViewController: UIViewController {
         setAddTarget()
         
         navi.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(80)
+            $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(68)
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringSettingViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringSettingViewController.swift
@@ -35,7 +35,6 @@ class FilteringSettingViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setUI()
         setAddTarget()
         
         navi.snp.makeConstraints {
@@ -49,10 +48,6 @@ class FilteringSettingViewController: UIViewController {
 // MARK: - UI & Layout
 
 extension FilteringSettingViewController {
-    
-    func setUI() {
-        self.tabBarController?.tabBar.isHidden = true
-    }
     
     func setAddTarget() {
         rootView.gradeButton1.addTarget(self, action: #selector(gradeButtonDidTap), for: .touchUpInside)
@@ -81,19 +76,21 @@ extension FilteringSettingViewController {
         }
         
         for gradeButton in gradeButtons_dict {
-            if gradeButton.key  == sender {
+            if gradeButton.key == sender {
                 gradeButton.key.backgroundColor = .terningMain
                 gradeButton.key.setTitleColor(.white, for: .normal)
                 gradeButton.key.isSelected.toggle()
                 grade = gradeButton.value
                 print("\(grade + 1)학년 선택되었습니다.")
-            } else if gradeButton.key == sender {
+                
+            } else if !gradeButton.key.isSelected {
                 continue
                 
             } else if gradeButton.key.isSelected {
                 gradeButton.key.backgroundColor = .clear
                 gradeButton.key.setTitleColor(.grey400, for: .normal)
                 gradeButton.key.isSelected = false
+                print("\(gradeButton.value)취소되었습니다.")
             }
         }
         return UIButton()
@@ -123,7 +120,7 @@ extension FilteringSettingViewController {
                     print("7개월 이상 선택되었습니다.")
                 }
                 
-            } else if periodButton.key == sender {
+            } else if !periodButton.key.isSelected {
                 continue
 
             } else if periodButton.key.isSelected {

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringSettingViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringSettingViewController.swift
@@ -12,7 +12,16 @@ import Then
 
 class FilteringSettingViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    var grade: Int = 0
+    var workingPeriod: Int = 0
+    var startYear: Int = 2024
+    var startMonth: Int = 8
+    
     // MARK: - UIComponents
+    
+    lazy var navi = CustomNavigationBar(self, type: .centerTitleWithLeftButton).setTitle("필터링 재설정")
     
     var rootView = FilteringSettingView()
     
@@ -20,12 +29,19 @@ class FilteringSettingViewController: UIViewController {
     
     override func loadView() {
         view = rootView
+        view.addSubview(navi)
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setUI()
         setAddTarget()
+        
+        navi.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(80)
+            $0.horizontalEdges.equalToSuperview()
+        }
     }
 }
 
@@ -33,66 +49,96 @@ class FilteringSettingViewController: UIViewController {
 
 extension FilteringSettingViewController {
     
+    func setUI() {
+        self.tabBarController?.tabBar.isHidden = true
+    }
+    
     func setAddTarget() {
         rootView.gradeButton1.addTarget(self, action: #selector(gradeButtonDidTap), for: .touchUpInside)
         rootView.gradeButton2.addTarget(self, action: #selector(gradeButtonDidTap), for: .touchUpInside)
         rootView.gradeButton3.addTarget(self, action: #selector(gradeButtonDidTap), for: .touchUpInside)
         rootView.gradeButton4.addTarget(self, action: #selector(gradeButtonDidTap), for: .touchUpInside)
+        
         rootView.periodButton1.addTarget(self, action: #selector(periodButtonDidTap), for: .touchUpInside)
         rootView.periodButton2.addTarget(self, action: #selector(periodButtonDidTap), for: .touchUpInside)
         rootView.periodButton3.addTarget(self, action: #selector(periodButtonDidTap), for: .touchUpInside)
+        
+        rootView.saveButton.addTarget(self, action: #selector(saveButtonDidTap), for: .touchUpInside)
     }
     
     // MARK: - @objc Function
     
     @objc
-    func gradeButtonDidTap(_ sender: UIButton) {
-        var gradeButtons: [UIButton] {
+    func gradeButtonDidTap(_ sender: UIButton) -> UIButton {
+        var gradeButtons_dict: [UIButton: Int] {
             return [
-                rootView.gradeButton1,
-                rootView.gradeButton2,
-                rootView.gradeButton3,
-                rootView.gradeButton4
+                rootView.gradeButton1: 0,
+                rootView.gradeButton2: 1,
+                rootView.gradeButton3: 2,
+                rootView.gradeButton4: 3
             ]
-            }
+        }
         
-        for gradeButton in gradeButtons {
-            if gradeButton == sender {
-                gradeButton.backgroundColor = .terningMain
-                gradeButton.setTitleColor(.white, for: .normal)
-                gradeButton.isSelected.toggle()
-                print("선택되었습니다.")
-            } else {
-                gradeButton.backgroundColor = .clear
-                gradeButton.setTitleColor(.grey400, for: .normal)
-                gradeButton.isSelected = false
-                print("취소되었습니다.")
+        for gradeButton in gradeButtons_dict {
+            if gradeButton.key  == sender {
+                gradeButton.key.backgroundColor = .terningMain
+                gradeButton.key.setTitleColor(.white, for: .normal)
+                gradeButton.key.isSelected.toggle()
+                grade = gradeButton.value
+                print("\(grade + 1)학년 선택되었습니다.")
+            } else if gradeButton.key == sender {
+                continue
+                
+            } else if gradeButton.key.isSelected {
+                gradeButton.key.backgroundColor = .clear
+                gradeButton.key.setTitleColor(.grey400, for: .normal)
+                gradeButton.key.isSelected = false
+            }
+        }
+        return UIButton()
+    }
+    
+    @objc
+    func periodButtonDidTap(_ sender: UIButton) {
+        var periodButtons_dict: [UIButton: Int] {
+            return [
+                rootView.periodButton1: 0,
+                rootView.periodButton2: 1,
+                rootView.periodButton3: 2
+            ]
+        }
+        
+        for periodButton in periodButtons_dict {
+            if periodButton.key  == sender {
+                periodButton.key.backgroundColor = .terningMain
+                periodButton.key.setTitleColor(.white, for: .normal)
+                periodButton.key.isSelected.toggle()
+                workingPeriod = periodButton.value
+                if workingPeriod == 0 {
+                    print("1개월 ~ 3개월 선택되었습니다.")
+                } else if workingPeriod == 1 {
+                    print("4개월 ~ 6개월 이상 선택되었습니다.")
+                } else if workingPeriod == 2 {
+                    print("7개월 이상 선택되었습니다.")
+                }
+                
+            } else if periodButton.key == sender {
+                continue
+
+            } else if periodButton.key.isSelected {
+                periodButton.key.backgroundColor = .clear
+                periodButton.key.setTitleColor(.grey400, for: .normal)
+                periodButton.key.isSelected = false
             }
         }
     }
     
     @objc
-    func periodButtonDidTap(_ sender: UIButton) {
-        var periodButtons: [UIButton] {
-            return [
-                rootView.periodButton1,
-                rootView.periodButton2,
-                rootView.periodButton3
-            ]
+    func saveButtonDidTap() {
+        rootView.monthPickerView.onDateSelected = { [weak self] year, month in
+            self?.startYear = year
+            self?.startMonth = month
         }
-        
-        for periodButton in periodButtons {
-            if periodButton == sender {
-                periodButton.backgroundColor = .terningMain
-                periodButton.setTitleColor(.white, for: .normal)
-                periodButton.isSelected.toggle()
-                print("선택되었습니다.")
-            } else {
-                periodButton.backgroundColor = .clear
-                periodButton.setTitleColor(.grey400, for: .normal)
-                periodButton.isSelected = false
-                print("취소되었습니다.")
-            }
-        }
+        print(grade, workingPeriod, startYear, startMonth)
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Home/HomeViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Home/HomeViewController.swift
@@ -274,6 +274,7 @@ extension HomeViewController: UICollectionViewDataSource {
 extension HomeViewController: FilteringButtonTappedProtocol {
     func filteringButtonTapped() {
         let filteringSettingView = FilteringSettingViewController()
+        filteringSettingView.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(filteringSettingView, animated: true)
     }
 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #37 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
## 1. 버튼 이벤트 클릭 로직을 약간 수정하였습니다.
버튼 클릭 후 다른 버튼을 클릭하면 전에 클릭되어 있던 버튼 외에 다른 버튼도 `isSelected`가 `false`가 되어서 `false`를 중복되게 하는 로직으로 구현했는데 이번 PR에서 이전에 선택된 버튼만 `isSelected`가 `false`가 되도록 수정하였습니다.

## 2. 네비게이션 바를 추가하였습니다.
상단의 네비게이션 바를 구현하였습니다. 커스텀 네비게이션 바가 나중에 수정된다고 해서 레이아웃만 잡아보았고 백버튼은 구현하지 않았습니다.

## 3. 필터링 재설정 화면에서 선택한 데이터를 한번에 출력하는 저장하기 버튼을 배치하고 구현했습니다.
UIButton+ extension을 이용해서 구현했고 일괄적으로 서버에 PUT 할 수 있게 정보를 한번에 출력되도록 했습니다. 
<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->
## 1. 버튼 이벤트 클릭 로직을 약간 수정했습니다.
```swift
@objc
func gradeButtonDidTap(_ sender: UIButton) -> UIButton {
    var gradeButtons_dict: [UIButton: Int] {
        return [
            rootView.gradeButton1: 0,
            rootView.gradeButton2: 1,
            rootView.gradeButton3: 2,
            rootView.gradeButton4: 3
        ]
    }
    
    for gradeButton in gradeButtons_dict {
        if gradeButton.key  == sender {
            gradeButton.key.backgroundColor = .terningMain
            gradeButton.key.setTitleColor(.white, for: .normal)
            gradeButton.key.isSelected.toggle()
            grade = gradeButton.value
            print("\(grade + 1)학년 선택되었습니다.")
        } else if gradeButton.key == sender {
            continue
            
        } else if gradeButton.key.isSelected {
            gradeButton.key.backgroundColor = .clear
            gradeButton.key.setTitleColor(.grey400, for: .normal)
            gradeButton.key.isSelected = false
        }
    }
    return UIButton()
}

@objc
func periodButtonDidTap(_ sender: UIButton) {
    var periodButtons_dict: [UIButton: Int] {
        return [
            rootView.periodButton1: 0,
            rootView.periodButton2: 1,
            rootView.periodButton3: 2
        ]
    }
    
    for periodButton in periodButtons_dict {
        if periodButton.key  == sender {
            periodButton.key.backgroundColor = .terningMain
            periodButton.key.setTitleColor(.white, for: .normal)
            periodButton.key.isSelected.toggle()
            workingPeriod = periodButton.value
            if workingPeriod == 0 {
                print("1개월 ~ 3개월 선택되었습니다.")
            } else if workingPeriod == 1 {
                print("4개월 ~ 6개월 이상 선택되었습니다.")
            } else if workingPeriod == 2 {
                print("7개월 이상 선택되었습니다.")
            }
            
        } else if periodButton.key == sender {
            continue

        } else if periodButton.key.isSelected {
            periodButton.key.backgroundColor = .clear
            periodButton.key.setTitleColor(.grey400, for: .normal)
            periodButton.key.isSelected = false
        }
    }
}
```

## 2. 필터링 재설정 화면에서 선택한 데이터를 한번에 출력하는 저장하기 버튼을 배치하고 구현했습니다.
`grade`와 `workingPeriod` 데이터는 위의 로직에서 받아오고 `startYear`과 `startMonth`의 경우 이 로직에서 받아옵니다. 커스텀 피커뷰에서 구현된 `onDataSelected` 클로저를 통해 `year`와 `month`를 받아옵니다.

기본값은 `2024 8`로 뜨도록 설정했습니다.(내 생일이 8월임 ㅋㅋ 암튼)

한가지 이슈는 피커를 선택하지 않으면 데이터를 받아오지 않습니다. 따라서 피커를 무조건 한 번 움직이고 저장을 누르고 또 다시 설정을 해야 반영이 됩니다. 이 이슈는 커스텀 피커 뷰의 설정 문제라 민지누나가 반영해서 수정한다고 해서 수정 이후, 제대로 작동할 것 같습니당
``` swift
var grade: Int = 0
var workingPeriod: Int = 0
var startYear: Int = 2024
var startMonth: Int = 8

@objc
func saveButtonDidTap() {
    rootView.monthPickerView.onDateSelected = { [weak self] year, month in
        self?.startYear = year
        self?.startMonth = month
    }
    print(grade, workingPeriod, startYear, startMonth)
}
```
<br/>

# 📘 ScreenShot
<img src = "https://github.com/user-attachments/assets/670e83a9-eda1-46aa-a3eb-071cb68b1972">

<br/>
