### PR TITLE
[Feat] #73 - 탐색 뷰 구현했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
+++ b/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
@@ -25,6 +25,12 @@
 		2D89C74F2C47E98B002B035F /* ProfileImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89C74E2C47E98B002B035F /* ProfileImageViewController.swift */; };
 		2D89C7512C47E99B002B035F /* ProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89C7502C47E99B002B035F /* ProfileImageView.swift */; };
 		2D89C7542C47E9AE002B035F /* ProfileImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89C7532C47E9AE002B035F /* ProfileImageCell.swift */; };
+		2D89C75D2C486DF7002B035F /* SortHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89C75C2C486DF7002B035F /* SortHeaderCell.swift */; };
+		2D89C75F2C486E05002B035F /* GraphicCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89C75E2C486E05002B035F /* GraphicCollectionViewCell.swift */; };
+		2D89C7612C486E12002B035F /* SearchResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89C7602C486E12002B035F /* SearchResultViewModel.swift */; };
+		2D89C7632C486E20002B035F /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89C7622C486E20002B035F /* SearchResultViewController.swift */; };
+		2D89C7652C486E2E002B035F /* SearchResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89C7642C486E2E002B035F /* SearchResultView.swift */; };
+		2D89C7672C486E53002B035F /* CustomSortButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89C7662C486E53002B035F /* CustomSortButton.swift */; };
 		2DC61EF32C4075E3009F991F /* JobDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EF22C4075E3009F991F /* JobDetailViewController.swift */; };
 		2DC61EF52C4075EB009F991F /* MainInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EF42C4075EB009F991F /* MainInfoTableViewCell.swift */; };
 		2DC61EF72C4075F3009F991F /* JobDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EF62C4075F3009F991F /* JobDetailViewModel.swift */; };
@@ -119,12 +125,12 @@
 		71E3C40D2C2423280026C4DD /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 71E3C40C2C2423280026C4DD /* .swiftlint.yml */; };
 		71E3C40F2C243B510026C4DD /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E3C40E2C243B510026C4DD /* UIView+.swift */; };
 		71E3C4122C243BDD0026C4DD /* getClassName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E3C4112C243BDD0026C4DD /* getClassName.swift */; };
-		B855485A2C47EEBB00EC67F6 /* UserProfileInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85548592C47EEBB00EC67F6 /* UserProfileInfoModel.swift */; };
-		B855485D2C48026B00EC67F6 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B855485C2C48026B00EC67F6 /* MyPageView.swift */; };
-		B855485F2C48027500EC67F6 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B855485E2C48027500EC67F6 /* MyPageViewController.swift */; };
 		71FFB2B22C47DD8000C60697 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 716E08AB2C44349A00469E3B /* Config.xcconfig */; };
 		71FFB2B52C47ECF200C60697 /* CustomBottmSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FFB2B42C47ECF200C60697 /* CustomBottmSheetViewController.swift */; };
 		71FFB2B82C48286300C60697 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FFB2B72C48286300C60697 /* SplashViewController.swift */; };
+		B855485A2C47EEBB00EC67F6 /* UserProfileInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85548592C47EEBB00EC67F6 /* UserProfileInfoModel.swift */; };
+		B855485D2C48026B00EC67F6 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B855485C2C48026B00EC67F6 /* MyPageView.swift */; };
+		B855485F2C48027500EC67F6 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B855485E2C48027500EC67F6 /* MyPageViewController.swift */; };
 		B86A67582C41166900CB90E5 /* FilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86A67572C41166800CB90E5 /* FilterButton.swift */; };
 		B871D7232C3E8836008D78C2 /* JobCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B871D7222C3E8835008D78C2 /* JobCardModel.swift */; };
 		B871D7252C3E8A53008D78C2 /* ScrapInfoHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B871D7242C3E8A53008D78C2 /* ScrapInfoHeaderCell.swift */; };
@@ -164,6 +170,12 @@
 		2D89C74E2C47E98B002B035F /* ProfileImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageViewController.swift; sourceTree = "<group>"; };
 		2D89C7502C47E99B002B035F /* ProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageView.swift; sourceTree = "<group>"; };
 		2D89C7532C47E9AE002B035F /* ProfileImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageCell.swift; sourceTree = "<group>"; };
+		2D89C75C2C486DF7002B035F /* SortHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortHeaderCell.swift; sourceTree = "<group>"; };
+		2D89C75E2C486E05002B035F /* GraphicCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphicCollectionViewCell.swift; sourceTree = "<group>"; };
+		2D89C7602C486E12002B035F /* SearchResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewModel.swift; sourceTree = "<group>"; };
+		2D89C7622C486E20002B035F /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
+		2D89C7642C486E2E002B035F /* SearchResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultView.swift; sourceTree = "<group>"; };
+		2D89C7662C486E53002B035F /* CustomSortButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSortButton.swift; sourceTree = "<group>"; };
 		2DC61EF22C4075E3009F991F /* JobDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobDetailViewController.swift; sourceTree = "<group>"; };
 		2DC61EF42C4075EB009F991F /* MainInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainInfoTableViewCell.swift; sourceTree = "<group>"; };
 		2DC61EF62C4075F3009F991F /* JobDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobDetailViewModel.swift; sourceTree = "<group>"; };
@@ -405,6 +417,50 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
+		2D89C7572C486DD2002B035F /* SearchResult */ = {
+			isa = PBXGroup;
+			children = (
+				2D89C75B2C486DED002B035F /* Cell */,
+				2D89C75A2C486DE4002B035F /* ViewController */,
+				2D89C7592C486DE0002B035F /* ViewModel */,
+				2D89C7582C486DDA002B035F /* View */,
+			);
+			path = SearchResult;
+			sourceTree = "<group>";
+		};
+		2D89C7582C486DDA002B035F /* View */ = {
+			isa = PBXGroup;
+			children = (
+				2D89C7642C486E2E002B035F /* SearchResultView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		2D89C7592C486DE0002B035F /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				2D89C7602C486E12002B035F /* SearchResultViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		2D89C75A2C486DE4002B035F /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				2D89C7622C486E20002B035F /* SearchResultViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		2D89C75B2C486DED002B035F /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				2D89C75C2C486DF7002B035F /* SortHeaderCell.swift */,
+				2D89C75E2C486E05002B035F /* GraphicCollectionViewCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 		2DC61EEE2C40759F009F991F /* JobDetail */ = {
 			isa = PBXGroup;
 			children = (
@@ -546,6 +602,7 @@
 				7121A1412C3AE99D0056DB8B /* Cell */,
 				7121A1322C396FB40056DB8B /* CustomButton.swift */,
 				2DC61F062C4145CD009F991F /* CustomScrapButton.swift */,
+				2D89C7662C486E53002B035F /* CustomSortButton.swift */,
 				2D4EE3862C3D7CB200E3E95B /* CustomOnboardingButton.swift */,
 				7121A1362C3A6C7C0056DB8B /* CustomAlertViewController.swift */,
 				2D4EE3842C3D6E6B00E3E95B /* CustomProgressView.swift */,
@@ -809,6 +866,7 @@
 			children = (
 				71FFB2B62C48284A00C60697 /* Splash */,
 				2DC985F42C456ED800D46729 /* Search */,
+				2D89C7572C486DD2002B035F /* SearchResult */,
 				71CCC06D2C3F369A00789A9B /* Calendar */,
 				2DC61F132C41A52E009F991F /* Login */,
 				2DC61EEE2C40759F009F991F /* JobDetail */,
@@ -1113,6 +1171,7 @@
 				7121A13E2C3A98E10056DB8B /* LabelFactory.swift in Sources */,
 				71780C562C45A81E0073B731 /* AuthInterceptor.swift in Sources */,
 				71B509212C41AD35006D8E56 /* JobListingCell.swift in Sources */,
+				2D89C7632C486E20002B035F /* SearchResultViewController.swift in Sources */,
 				2D4EE3AB2C3E854E00E3E95B /* ValidationMessage.swift in Sources */,
 				71780C542C45A7DD0073B731 /* NetworkLoggerPlugin.swift in Sources */,
 				71780C502C45A2870073B731 /* AnnouncementsTargetType.swift in Sources */,
@@ -1140,6 +1199,7 @@
 				B871D7352C3ECF37008D78C2 /* ScrapedAndDeadlineModel.swift in Sources */,
 				2D4EE3A22C3E788200E3E95B /* ProfileViewModel.swift in Sources */,
 				2DC985F92C456F9300D46729 /* RecommendCollectionViewCell.swift in Sources */,
+				2D89C75F2C486E05002B035F /* GraphicCollectionViewCell.swift in Sources */,
 				2DC986032C45701D00D46729 /* SearchViewModel.swift in Sources */,
 				71CCC0712C3F36DE00789A9B /* TNCalendarViewController.swift in Sources */,
 				7121A1512C3B09E10056DB8B /* Result+.swift in Sources */,
@@ -1174,6 +1234,7 @@
 				71780C522C45A4950073B731 /* SearchTargetType.swift in Sources */,
 				B8C5DB732C3F39C700865B1A /* FilteringSettingViewController.swift in Sources */,
 				2DC9860D2C4605FC00D46729 /* AdvertisementsModel.swift in Sources */,
+				2D89C75D2C486DF7002B035F /* SortHeaderCell.swift in Sources */,
 				B86A67582C41166900CB90E5 /* FilterButton.swift in Sources */,
 				2DC985FE2C456FC300D46729 /* SearchView.swift in Sources */,
 				2D4EE3A62C3E78A200E3E95B /* ProfileViewController.swift in Sources */,
@@ -1182,7 +1243,9 @@
 				B8D5493F2C45B46D00553BB5 /* NonJobCardHeaderCell.swift in Sources */,
 				2DC61F192C41B261009F991F /* LoginView.swift in Sources */,
 				7121A1332C396FB40056DB8B /* CustomButton.swift in Sources */,
+				2D89C7652C486E2E002B035F /* SearchResultView.swift in Sources */,
 				B8D5493B2C450E9600553BB5 /* FilterHeaderCell.swift in Sources */,
+				2D89C7672C486E53002B035F /* CustomSortButton.swift in Sources */,
 				2DC61EF72C4075F3009F991F /* JobDetailViewModel.swift in Sources */,
 				B871D7232C3E8836008D78C2 /* JobCardModel.swift in Sources */,
 				2DC985F72C456F7E00D46729 /* AdvertisementCollectionViewCell.swift in Sources */,
@@ -1194,6 +1257,7 @@
 				71B509232C41BD90006D8E56 /* CompositionalLayout.swift in Sources */,
 				B8BE0E142C46D38700B3D298 /* UserFilteringInfoModel.swift in Sources */,
 				71D7E6ED2C2FF42500C54EA7 /* TNTabBarController.swift in Sources */,
+				2D89C7612C486E12002B035F /* SearchResultViewModel.swift in Sources */,
 				2DC61F152C41AB54009F991F /* LoginViewController.swift in Sources */,
 				B8D549392C450C9600553BB5 /* MainHomeView.swift in Sources */,
 				2DC61F052C40926D009F991F /* JobDetailView.swift in Sources */,

--- a/Terning-iOS/Terning-iOS/Network/TargetType/ScrapsTargetType.swift
+++ b/Terning-iOS/Terning-iOS/Network/TargetType/ScrapsTargetType.swift
@@ -9,9 +9,9 @@ import Foundation
 import Moya
 
 enum ScrapsTargetType {
-    case addScrap(internshipAnnouncementId: Double, color: Int)
-    case removeScrap(scrapId: Double)
-    case patchScrap(scrapId: Double, color: Int)
+    case addScrap(internshipAnnouncementId: Int, color: Int)
+    case removeScrap(scrapId: Int)
+    case patchScrap(scrapId: Int, color: Int)
 }
 
 extension ScrapsTargetType: TargetType {

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomSearchView.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomSearchView.swift
@@ -55,6 +55,8 @@ final class CustomSearchView: UIView, UITextFieldDelegate {
     // MARK: - UI & Layout
     
     private func setUI() {
+        self.backgroundColor = .clear
+        
         addSubviews(
             iconImageView,
             textField,

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomSortButton.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomSortButton.swift
@@ -1,0 +1,52 @@
+//
+//  CustomSortButton.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/17/24.
+//
+
+import UIKit
+
+final class CustomSortButton: UIButton {
+    
+    // MARK: - Properties
+   
+    // MARK: - Init
+    
+    public init() {
+        
+        super.init(frame: .zero)
+        
+        setStyle()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension CustomSortButton {
+    private func setStyle() {
+        setTitle("채용 마감 이른순", for: .normal)
+        
+        setTitleColor(.terningBlack, for: .normal)
+        titleLabel?.font = .button3
+        
+        setImage(.icDownArrow, for: .normal)
+        imageView?.contentMode = .scaleAspectFit
+        
+        semanticContentAttribute = .forceRightToLeft
+        
+        backgroundColor = .clear
+        
+        contentHorizontalAlignment = .right
+        contentVerticalAlignment = .center
+        
+        self.snp.makeConstraints {
+            $0.height.equalTo(17)
+            $0.width.equalTo(128)
+        }
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Data/Home/JobCardModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Home/JobCardModel.swift
@@ -8,11 +8,11 @@
 import UIKit
 
 struct JobCardModel {
-    let internshipAnnouncementId: Double
+    let internshipAnnouncementId: Int
     let title: String
     let dDay: String
     let workingPeriod: String
-    let companyImage: UIImage
+    let companyImage: String
     let isScraped: Bool
 }
 
@@ -25,7 +25,7 @@ extension JobCardModel {
                 title: "[번개장터] Content Marketer",
                 dDay: "D-DAY",
                 workingPeriod: "1개월",
-                companyImage: UIImage(resource: .icHome),
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
                 isScraped: false
             ),
             
@@ -34,7 +34,7 @@ extension JobCardModel {
                 title: "[보더엑스] 글로벌 마케팅 AE (채용연계형 인턴십)",
                 dDay: "D-8",
                 workingPeriod: "3개월",
-                companyImage: UIImage(resource: .icHome),
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
                 isScraped: false
             ),
             
@@ -43,7 +43,7 @@ extension JobCardModel {
                 title: "[카카오페이] 카카오페이 보험 운영 어시스턴트 채용",
                 dDay: "D-17",
                 workingPeriod: "2개월",
-                companyImage: UIImage(resource: .icHome),
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
                 isScraped: true
             ),
             
@@ -52,7 +52,7 @@ extension JobCardModel {
                 title: "[번개장터] Data Analyst",
                 dDay: "지원 마감",
                 workingPeriod: "3개월",
-                companyImage: UIImage(resource: .icHome),
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
                 isScraped: false
             ),
             
@@ -61,7 +61,7 @@ extension JobCardModel {
                 title: "[번개장터] Data Analyst",
                 dDay: "지원 마감",
                 workingPeriod: "3개월",
-                companyImage: UIImage(resource: .icHome),
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
                 isScraped: false
             ),
             
@@ -70,7 +70,7 @@ extension JobCardModel {
                 title: "[카카오페이] 카카오페이 보험 운영 어시스턴트 채용",
                 dDay: "D-17",
                 workingPeriod: "2개월",
-                companyImage: UIImage(resource: .icHome),
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
                 isScraped: true
             ),
             
@@ -79,7 +79,7 @@ extension JobCardModel {
                 title: "[번개장터] Content Marketer",
                 dDay: "D-DAY",
                 workingPeriod: "1개월",
-                companyImage: UIImage(resource: .icHome),
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
                 isScraped: false
             ),
             
@@ -88,7 +88,7 @@ extension JobCardModel {
                 title: "[카카오페이] 카카오페이 보험 운영 어시스턴트 채용",
                 dDay: "D-17",
                 workingPeriod: "2개월",
-                companyImage: UIImage(resource: .icHome),
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
                 isScraped: true
             ),
             
@@ -97,7 +97,7 @@ extension JobCardModel {
                 title: "[보더엑스] 글로벌 마케팅 AE (채용연계형 인턴십)",
                 dDay: "D-8",
                 workingPeriod: "3개월",
-                companyImage: UIImage(resource: .icHome),
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
                 isScraped: false
             ),
             
@@ -106,7 +106,7 @@ extension JobCardModel {
                 title: "[번개장터] Content Marketer",
                 dDay: "D-DAY",
                 workingPeriod: "1개월",
-                companyImage: UIImage(resource: .icHome),
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
                 isScraped: false
             )
         ]

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Home/Cells/JobCardCells/InavailableFilterView.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Home/Cells/JobCardCells/InavailableFilterView.swift
@@ -69,3 +69,32 @@ extension InavailableFilterView {
         }
     }
 }
+
+// MARK: - Bind
+
+extension InavailableFilterView {
+    public func bind(title: String) {
+        let fullText: String
+        let finalTitle: String
+        
+        if title.count > 16 {
+            finalTitle = "\(title.prefix(16))..."
+            fullText = "\(finalTitle)에\n해당하는 검색 결과가 없어요"
+        } else {
+            finalTitle = title
+            fullText = "\(finalTitle)에 해당하는 검색 결과가 없어요"
+        }
+        
+        let attributedString = NSMutableAttributedString(string: fullText)
+        
+        let titleRange = (fullText as NSString).range(of: finalTitle)
+        attributedString.addAttribute(.foregroundColor, value: UIColor.terningMain, range: titleRange)
+        
+        inavailableLabel.attributedText = attributedString
+        
+        inavailableLabel.snp.updateConstraints {
+            $0.top.equalTo(inavailableIcon.snp.bottom).offset(16)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Home/Cells/JobCardCells/JobCardScrapedCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Home/Cells/JobCardCells/JobCardScrapedCell.swift
@@ -11,7 +11,7 @@ import SnapKit
 import Then
 
 protocol ScrapDidTapDelegate: AnyObject {
-    func scrapButtonDidTap(id: Double)
+    func scrapButtonDidTap(id: Int)
 }
 
 final class JobCardScrapedCell: UICollectionViewCell {
@@ -22,7 +22,7 @@ final class JobCardScrapedCell: UICollectionViewCell {
     
     private var isScrapButtonSelected: Bool = false
     
-    private var internshipAnnouncementId: Double? = 0
+    private var internshipAnnouncementId: Int? = 0
     
     // MARK: - UIComponents
     
@@ -150,8 +150,7 @@ extension JobCardScrapedCell {
     
     func bindData(model: JobCardModel) {
         self.internshipAnnouncementId = model.internshipAnnouncementId
-        //      self.jobCardCoverImage.setImage(with: model.companyImage) URL로 이미지 받아올 때 사용예시라 남겨놨습니다.
-        self.jobCardCoverImage.image = model.companyImage
+        self.jobCardCoverImage.setImage(with: model.companyImage, placeholder: "placeholder_image")
         self.daysRemaining.text = model.dDay
         self.jobLabel.text = model.title
         self.period.text = model.workingPeriod

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Home/MainHomeViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Home/MainHomeViewController.swift
@@ -422,7 +422,7 @@ extension MainHomeViewController: UICollectionViewDelegate {
 
 extension MainHomeViewController: ScrapDidTapDelegate {
     
-    func scrapButtonDidTap(id: Double) {
+    func scrapButtonDidTap(id: Int) {
         guard let indexPath = self.indexPath(forInternshipAnnouncementId: id),
               let cell = self.rootView.collectionView.cellForItem(at: indexPath) as? JobCardScrapedCell else {
             return
@@ -435,7 +435,7 @@ extension MainHomeViewController: ScrapDidTapDelegate {
         }
     }
     
-    private func showScrapAlert(id: Double, alertType: AlertType, cell: JobCardScrapedCell) {
+    private func showScrapAlert(id: Int, alertType: AlertType, cell: JobCardScrapedCell) {
         let customAlertVC = CustomAlertViewController(alertType: alertType)
         
         if alertType == .custom {
@@ -461,7 +461,7 @@ extension MainHomeViewController: ScrapDidTapDelegate {
         self.present(customAlertVC, animated: false)
     }
     
-    private func scrapAnnouncement(internshipAnnouncementId: Double, color: Int, cell: JobCardScrapedCell) {
+    private func scrapAnnouncement(internshipAnnouncementId: Int, color: Int, cell: JobCardScrapedCell) {
         providers.request(.addScrap(internshipAnnouncementId: internshipAnnouncementId, color: color)) { [weak self] result in
             LoadingIndicator.hideLoading()
             guard let self = self else { return }
@@ -482,7 +482,7 @@ extension MainHomeViewController: ScrapDidTapDelegate {
         }
     }
     
-    private func cancelScrapAnnouncement(internshipAnnouncementId: Double, cell: JobCardScrapedCell) {
+    private func cancelScrapAnnouncement(internshipAnnouncementId: Int, cell: JobCardScrapedCell) {
         providers.request(.removeScrap(scrapId: internshipAnnouncementId)) { [weak self] result in
             LoadingIndicator.hideLoading()
             guard let self = self else { return }
@@ -503,7 +503,7 @@ extension MainHomeViewController: ScrapDidTapDelegate {
         }
     }
     
-    private func indexPath(forInternshipAnnouncementId id: Double) -> IndexPath? {
+    private func indexPath(forInternshipAnnouncementId id: Int) -> IndexPath? {
         for (index, model) in cardModelItems.enumerated() where model.internshipAnnouncementId == id {
             return IndexPath(row: index, section: HomeSection.jobCard.rawValue)
         }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/GraphicCollectionViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/GraphicCollectionViewCell.swift
@@ -1,0 +1,49 @@
+//
+//  GraphicCollectionViewCell.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/18/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class GraphicCollectionViewCell: UICollectionViewCell {
+    
+    // MARK: - UI Components
+    
+    private let imageView = UIImageView().then {
+        $0.image = .profile0
+        $0.contentMode = .scaleAspectFill
+        $0.layer.masksToBounds = true
+    }
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        
+        super.init(frame: frame)
+        
+        self.setHierarchy()
+        self.setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension GraphicCollectionViewCell {
+    private func setHierarchy() {
+        contentView.addSubview(imageView)
+    }
+    
+    private func setLayout() {
+        imageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/SortHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/SortHeaderCell.swift
@@ -1,0 +1,57 @@
+//
+//  SortHeaderCell.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/17/24.
+//
+
+import UIKit
+
+import RxSwift
+
+import SnapKit
+
+final class SortHeaderCell: UICollectionReusableView {
+    
+    // MARK: - UIComponents
+
+    var sortButton = CustomSortButton()
+    var sortBySubject = PublishSubject<String>()
+    
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setHierarchy()
+        setLayout()
+        bind()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension SortHeaderCell {
+    func setHierarchy() {
+        addSubview(sortButton)
+    }
+    
+    func setLayout() {
+        sortButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(22)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    private func bind() {
+        sortButton.rx.tap
+            .map { "정렬기준" }
+            .bind(to: sortBySubject)
+            .disposed(by: disposeBag)
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/View/SearchResultView.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/View/SearchResultView.swift
@@ -1,0 +1,208 @@
+//
+//  SearchResultView.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/17/24.
+//
+
+import UIKit
+
+import RxSwift
+
+import SnapKit
+
+final class SearchResultView: UIView {
+    
+    // MARK: - Properties
+    
+    var jobCardModel: [JobCardModel]?
+    var sortBySubject = PublishSubject<String>()
+    
+    // MARK: - UI Components
+    
+    private let navigationBar = CustomNavigationBar(type: .centerTitleWithLeftButton)
+    
+    let searchView = CustomSearchView()
+    
+    let searchTitleLabel = LabelFactory.build(
+        text: "어떤 공고를\n찾고 계시나요?",
+        font: .heading2,
+        textColor: .grey500,
+        textAlignment: .left
+    ).then {
+        $0.numberOfLines = 2
+    }
+    
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewCompositionalLayout { (sectionIndex, _) -> NSCollectionLayoutSection? in
+        guard let section = SearchResultType(rawValue: sectionIndex) else { return nil }
+        switch section {
+        case .graphic:
+            return SearchResultView.createGraphicSection()
+        case .search:
+            return SearchResultView.createSearchSection()
+        case .noSearch:
+            return SearchResultView.createNoSearchSection()
+        }
+    })
+    
+    // MARK: - init
+    
+    override init(frame: CGRect) {
+        
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layout
+
+extension SearchResultView {
+    private func setUI() {
+        navigationBar.setTitle("검색 결과")
+        
+        collectionView.register(
+            JobCardScrapedCell.self,
+            forCellWithReuseIdentifier: JobCardScrapedCell.className
+        )
+        collectionView.register(
+            GraphicCollectionViewCell.self,
+            forCellWithReuseIdentifier: GraphicCollectionViewCell.className
+        )
+        collectionView.register(
+            InavailableFilterView.self,
+            forCellWithReuseIdentifier: InavailableFilterView.className
+        )
+        collectionView.register(
+            SortHeaderCell.self,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: SortHeaderCell.className
+        )
+        
+        collectionView.backgroundColor = .white
+    }
+    
+    private func setHierarchy() {
+        addSubviews(
+            navigationBar,
+            searchTitleLabel,
+            searchView,
+            collectionView
+        )
+    }
+    
+    private func setLayout() {
+        navigationBar.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(68)
+        }
+        
+        searchTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom).offset(14)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        searchView.snp.makeConstraints {
+            $0.top.equalTo(searchTitleLabel.snp.bottom).offset(13)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(searchView.snp.bottom).offset(8)
+            $0.horizontalEdges.bottom.equalToSuperview()
+        }
+        
+    }
+}
+
+// MARK: - Methods
+
+extension SearchResultView {
+    func updateLayout() {
+        navigationBar.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(68)
+        }
+        
+        searchTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom).offset(14)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        searchView.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(searchView.snp.bottom).offset(20)
+            $0.horizontalEdges.bottom.equalToSuperview()
+        }
+        setNeedsLayout()
+    }
+}
+
+// MARK: - UICollectionViewCompositionalLayout
+
+extension SearchResultView {
+    private static func createGraphicSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(247)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(247)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        
+        return section
+    }
+    
+    private static func createSearchSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(116)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(116)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+      
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 0, trailing: 0)
+        
+        return section
+    }
+
+    private static func createNoSearchSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(100)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(100)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        
+        return section
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -1,0 +1,181 @@
+//
+//  SearchResultViewController.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/17/24.
+//
+//
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+import SnapKit
+
+@frozen
+enum SearchResultType: Int, CaseIterable {
+    case graphic = 0
+    case search = 1
+    case noSearch = 2
+}
+
+final class SearchResultViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    private let viewModel: SearchResultViewModel
+    private let disposeBag = DisposeBag()
+    private let sortBySubject = BehaviorSubject<String>(value: "deadlineSoon")
+    private let pageSubject = BehaviorSubject<Int>(value: 0)
+    private var textFieldKeyword: String?
+    
+    // MARK: - UI Components
+    
+    let searchResultView = SearchResultView()
+    
+    // MARK: - Init
+    
+    init(viewModel: SearchResultViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - View Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        
+        setHierarchy()
+        setLayout()
+        setDelegate()
+        bindViewModel()
+    }
+}
+
+// MARK: - UI & Layout
+
+extension SearchResultViewController {
+    private func setHierarchy() {
+        view.addSubview(searchResultView)
+    }
+    
+    private func setLayout() {
+        searchResultView.snp.makeConstraints {
+            $0.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+}
+
+// MARK: - Bind
+
+extension SearchResultViewController {
+    private func bindViewModel() {
+        var firstSearch = true
+        
+        let keyword = searchResultView.searchView.textField.rx.text.orEmpty.asObservable()
+        
+        let searchTrigger = searchResultView.searchView.textField.rx.controlEvent(.editingDidEndOnExit)
+            .withLatestFrom(keyword)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+            .map { _ in () }
+        
+        searchTrigger
+            .withLatestFrom(keyword)
+            .subscribe(onNext: { keyword in
+                print("텍스트 필드 값: \(keyword)")
+                if firstSearch {
+                    firstSearch = false
+                    self.searchResultView.searchTitleLabel.isHidden = true
+                    self.searchResultView.updateLayout()
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        let input = SearchResultViewModel.Input(
+            keyword: searchTrigger.withLatestFrom(keyword),
+            sortBy: sortBySubject.asObservable(),
+            page: pageSubject.asObservable(),
+            size: Observable.just(10),
+            searchTrigger: searchTrigger
+        )
+        
+        let output = viewModel.transform(input: input, disposeBag: disposeBag)
+        
+        output.jobCards
+            .drive(onNext: { [weak self] jobCardModel in
+                self?.searchResultView.jobCardModel = jobCardModel
+                self?.searchResultView.collectionView.reloadData()
+            })
+            .disposed(by: disposeBag)
+        
+        output.keyword
+            .drive(onNext: { [weak self] keyword in
+                self?.textFieldKeyword = keyword
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+// MARK: - Methods
+
+extension SearchResultViewController {
+    private func setDelegate() {
+        searchResultView.collectionView.delegate = self
+        searchResultView.collectionView.dataSource = self
+        
+        self.hideKeyboardWhenTappedAround()
+    }
+}
+
+// MARK: - UICollectionViewDataSource, UICollectionViewDelegate
+
+extension SearchResultViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return SearchResultType.allCases.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        switch SearchResultType(rawValue: section) {
+        case .graphic:
+            return searchResultView.jobCardModel == nil ? 1 : 0
+        case .search:
+            return searchResultView.jobCardModel?.isEmpty == false ? (searchResultView.jobCardModel?.count ?? 0) : 0
+        case .noSearch:
+            return searchResultView.jobCardModel?.isEmpty == true ? 1 : 0
+        default:
+            return 0
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        switch SearchResultType(rawValue: indexPath.section) {
+        case .graphic:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GraphicCollectionViewCell.className, for: indexPath) as? GraphicCollectionViewCell else {
+                return UICollectionViewCell()
+            }
+            return cell
+            
+        case .search:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: JobCardScrapedCell.className, for: indexPath) as? JobCardScrapedCell, let jobCards = searchResultView.jobCardModel else {
+                return UICollectionViewCell()
+            }
+            cell.bindData(model: jobCards[indexPath.item])
+            return cell
+            
+        case .noSearch:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: InavailableFilterView.className, for: indexPath) as? InavailableFilterView, let title = self.textFieldKeyword else {
+                return UICollectionViewCell()
+            }
+            cell.bind(title: title)
+            return cell
+            
+        default:
+            return UICollectionViewCell()
+        }
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
@@ -1,0 +1,68 @@
+//
+//  SearchResultViewModel.swift
+//  Terning-iOS
+//
+//  Created by 정민지 on 7/17/24.
+//
+
+import RxSwift
+import RxCocoa
+
+final class SearchResultViewModel: ViewModelType {
+    
+    // MARK: - Input
+    
+    struct Input {
+        let keyword: Observable<String>
+        let sortBy: Observable<String>
+        let page: Observable<Int>
+        let size: Observable<Int>
+        let searchTrigger: Observable<Void>
+    }
+    
+    // MARK: - Output
+    
+    struct Output {
+        let jobCards: Driver<[JobCardModel]>
+        let keyword: Driver<String>
+    }
+    
+    // MARK: - Transform
+    
+    func transform(input: Input, disposeBag: DisposeBag) -> Output {
+        let jobCards = input.searchTrigger
+            .withLatestFrom(Observable.combineLatest(input.keyword, input.sortBy, input.page, input.size))
+            .flatMapLatest { keyword, sortBy, page, size in
+                self.fetchJobCards(keyword: keyword, sortBy: sortBy, page: page, size: size)
+                    .catchAndReturn([])
+            }
+            .asDriver(onErrorJustReturn: [])
+        
+        let keyword = input.keyword.asDriver(onErrorJustReturn: "")
+        
+        return Output(jobCards: jobCards, keyword: keyword)
+    }
+    
+    private func fetchJobCards(keyword: String, sortBy: String, page: Int, size: Int) -> Observable<[JobCardModel]> {
+        let dummyData: [JobCardModel] = [
+            JobCardModel(
+                internshipAnnouncementId: 23,
+                title: "[유한킴벌리]그린캠프 w. 대학생 숲 활동가 모집",
+                dDay: "D-2",
+                workingPeriod: "2개월",
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                isScraped: false
+            ),
+            JobCardModel(
+                internshipAnnouncementId: 2,
+                title: "[유한킴벌리]그린캠프 w. 대학생 숲 활동가 모집",
+                dDay: "D-2",
+                workingPeriod: "3개월",
+                companyImage: "https://images.unsplash.com/photo-1543852786-1cf6624b9987?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                isScraped: true
+            )
+        ]
+        
+        return Observable.just(dummyData)
+    }
+}


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #73 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
기존에 만들어두신 `JobCardScrapedCell`, `InavailableFilterView`, `JobCardModel` 활용해서 구현했습니다! `JobCardModel`의 이미지 데이터를 UIImage에서 String으로 변경하였고 그에 맞게 bind도 변경해놓았습니다!
```swift
    // MARK: - Methods
    
    func bindData(model: JobCardModel) {
        self.internshipAnnouncementId = model.internshipAnnouncementId
        self.jobCardCoverImage.setImage(with: model.companyImage, placeholder: "placeholder_image")
        self.daysRemaining.text = model.dDay
        self.jobLabel.text = model.title
        self.period.text = model.workingPeriod
        self.scrapButton.isSelected = model.isScraped
    }
```

현재 SortHeaderCell과 CustomSortButton은 UI만 만들어놓은 상태이고, 화면에 추가하거나 로직을 추가하지 않았습니다. 

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

```swift
    private let sortBySubject = BehaviorSubject<String>(value: "deadlineSoon")
    private let pageSubject = BehaviorSubject<Int>(value: 0)
    private var textFieldKeyword: String?
```

```swift
        let keyword = searchResultView.searchView.textField.rx.text.orEmpty.asObservable()
        
        let searchTrigger = searchResultView.searchView.textField.rx.controlEvent(.editingDidEndOnExit)
            .withLatestFrom(keyword)
            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
            .map { _ in () }
        
        searchTrigger
            .withLatestFrom(keyword)
            .subscribe(onNext: { keyword in
                print("텍스트 필드 값: \(keyword)")
                if firstSearch {
                    firstSearch = false
                    self.searchResultView.searchTitleLabel.isHidden = true
                    self.searchResultView.updateLayout()
                }
            })
            .disposed(by: disposeBag)
        
        let input = SearchResultViewModel.Input(
            keyword: searchTrigger.withLatestFrom(keyword),
            sortBy: sortBySubject.asObservable(),
            page: pageSubject.asObservable(),
            size: Observable.just(10),
            searchTrigger: searchTrigger
        )
```
바뀌고 있는 텍스트 필드를 관찰하게 해놓았고, 텍스트필드에서 입력이 완료가 되었을 때(키보드의 엔터를 눌렀을때)만 트리거를 발생시키도록 하였습니다. 트리거가 일어나야만 ViewModel로 가서 아웃풋을 출력하게 됩니다. 
` var firstSearch = true`를 선언하여, 처음으로 트리거가 발생하였을때만 `Graphic 화면`을 보일 수 있도록 하였습니다. 이후에 일어나는 검색에서는 검색 결과창과 "해당하는 검색이 없습니다" 셀만 볼 수 있습니다.


```swift
        let output = viewModel.transform(input: input, disposeBag: disposeBag)
        
        output.jobCards
            .drive(onNext: { [weak self] jobCardModel in
                self?.searchResultView.jobCardModel = jobCardModel
                self?.searchResultView.collectionView.reloadData()
            })
            .disposed(by: disposeBag)
        
        output.keyword
            .drive(onNext: { [weak self] keyword in
                self?.textFieldKeyword = keyword
            })
            .disposed(by: disposeBag)
    }
```
아웃풋에서 더미 데이터와 검색한 키워드를 가져왔고, 더미데이터의 경우 추후 API 연결로 교체될 예정입니다. 
아직 서버 responseDTO에 `scrapId`와 `isScrap`이 통일되어있지 않아, 반영하지 않았고 추후 API 연결하는 과정에서 수정할 예정입니다. 
같은 모델을 사용하는 만큼 작업하실때 말씀해주시면 감사하겠습니다!


```swift
    func updateLayout() {
        navigationBar.snp.makeConstraints {
            $0.top.horizontalEdges.equalToSuperview()
            $0.height.equalTo(68)
        }
        
        searchTitleLabel.snp.makeConstraints {
            $0.top.equalTo(navigationBar.snp.bottom).offset(14)
            $0.horizontalEdges.equalToSuperview().inset(20)
        }
        
        searchView.snp.makeConstraints {
            $0.top.equalTo(navigationBar.snp.bottom)
            $0.horizontalEdges.equalToSuperview().inset(20)
        }
        
        collectionView.snp.makeConstraints {
            $0.top.equalTo(searchView.snp.bottom).offset(20)
            $0.horizontalEdges.bottom.equalToSuperview()
        }
        setNeedsLayout()
    }
```
검색의 초기 화면인 Graphic화면에서 검색 결과 화면으로 바뀔때 
`SearchResultView`의 레이아웃이 바뀌는 부분이 많아서 
처음 트리거가 발생하였을때 위의 해당 함수` updateLayout()`을 호출하여 Layout을 다시 잡을 수 있도록 하였습니다. 

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->
검색 결과 있을때 



https://github.com/user-attachments/assets/f667ff03-e47f-4b40-8949-97b88d621ade



----------------------------------------------------------------------------------------------------------------------
검색 결과 없을때



https://github.com/user-attachments/assets/0f65e197-9d0c-4dac-8489-ef400832adfa


-> 지금은 더미데이터라서 검색 결과 있을 때랑 없을 때를 동시에 보여줄 수 없었습니다!

<br/>
