### PR TITLE
[Fix] #131 - 곧 마감되는 공고카드의 디자인 및 api 명세서의 변경사항을 반영해주었습니다. 

### DIFF
--- a/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Colors/terning_sub3.colorset/Contents.json
+++ b/Terning-iOS/Terning-iOS/Resource/Assets.xcassets/Colors/terning_sub3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE9",
+          "green" : "0xF1",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE9",
+          "green" : "0xF1",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Terning-iOS/Terning-iOS/Resource/Utils/CompositionalLayout.swift
+++ b/Terning-iOS/Terning-iOS/Resource/Utils/CompositionalLayout.swift
@@ -128,7 +128,7 @@ struct CompositionalLayout {
                 return section
                 
             } else if sectionNumber == 1 {
-                let itemWidth: CGFloat = 246/375
+                let itemWidth: CGFloat = (246/375).adjusted
                 
                 let item = NSCollectionLayoutItem(
                     layoutSize: .init(
@@ -139,7 +139,7 @@ struct CompositionalLayout {
                 
                 item.contentInsets.trailing = 12
                 
-                let groupHeight: CGFloat = 116
+                let groupHeight: CGFloat = 116.adjustedH
                 
                 let group = NSCollectionLayoutGroup.horizontal(
                     layoutSize: .init(

--- a/Terning-iOS/Terning-iOS/Resource/Utils/CompositionalLayout.swift
+++ b/Terning-iOS/Terning-iOS/Resource/Utils/CompositionalLayout.swift
@@ -128,19 +128,23 @@ struct CompositionalLayout {
                 return section
                 
             } else if sectionNumber == 1 {
+                let itemWidth: CGFloat = 246/375
+                
                 let item = NSCollectionLayoutItem(
                     layoutSize: .init(
-                        widthDimension: .fractionalWidth(0.5),
+                        widthDimension: .fractionalWidth(itemWidth),
                         heightDimension: .fractionalHeight(1)
                     )
                 )
                 
                 item.contentInsets.leading = 12
                 
+                let groupHeight: CGFloat = 116
+                
                 let group = NSCollectionLayoutGroup.horizontal(
                     layoutSize: .init(
-                        widthDimension: .fractionalWidth(0.8),
-                        heightDimension: .absolute(132)
+                        widthDimension: .fractionalWidth(1.0),
+                        heightDimension: .absolute(groupHeight)
                     ),
                     subitems: [item]
                 )

--- a/Terning-iOS/Terning-iOS/Resource/Utils/CompositionalLayout.swift
+++ b/Terning-iOS/Terning-iOS/Resource/Utils/CompositionalLayout.swift
@@ -128,35 +128,63 @@ struct CompositionalLayout {
                 return section
                 
             } else if sectionNumber == 1 {
-                let itemWidth: CGFloat = (246/375).adjusted
                 
-                let item = NSCollectionLayoutItem(
-                    layoutSize: .init(
-                        widthDimension: .fractionalWidth(itemWidth),
-                        heightDimension: .fractionalHeight(1)
+                let HomeVC = NewHomeViewController()
+                
+                if HomeVC.todayDeadlineLists.isEmpty {
+                    let itemWidth: CGFloat = 327.adjusted
+                    
+                    let item = NSCollectionLayoutItem(
+                        layoutSize: .init(
+                            widthDimension: .absolute(itemWidth),
+                            heightDimension: .fractionalHeight(1)
+                        )
                     )
-                )
-                
-                item.contentInsets.trailing = 12
-                
-                let groupHeight: CGFloat = 116.adjustedH
-                
-                let group = NSCollectionLayoutGroup.horizontal(
-                    layoutSize: .init(
-                        widthDimension: .fractionalWidth(1.0),
-                        heightDimension: .absolute(groupHeight)
-                    ),
-                    subitems: [item]
-                )
-                
-                group.interItemSpacing = .fixed(-5)
-                
-                let section = NSCollectionLayoutSection(group: group)
-                
-                section.orthogonalScrollingBehavior = .continuous
-                section.contentInsets = .init(top: 0, leading: 24, bottom: 20, trailing: 0)
-                
-                return section
+                    
+                    let groupHeight: CGFloat = 116.adjustedH
+                    
+                    let group = NSCollectionLayoutGroup.horizontal(
+                        layoutSize: .init(
+                            widthDimension: .fractionalWidth(1.0),
+                            heightDimension: .absolute(groupHeight)
+                        ), subitems: [item]
+                    )
+                    
+                    let section = NSCollectionLayoutSection(group: group)
+                    section.contentInsets = .init(top: 0, leading: 24, bottom: 20, trailing: 0)
+                    
+                    return section
+                    
+                } else {
+                    let itemWidth: CGFloat = 246.adjusted
+                    
+                    let item = NSCollectionLayoutItem(
+                        layoutSize: .init(
+                            widthDimension: .absolute(itemWidth),
+                            heightDimension: .fractionalHeight(1)
+                        )
+                    )
+                    
+                    item.contentInsets.trailing = 12
+                    
+                    let groupHeight: CGFloat = 116.adjustedH
+                    
+                    let group = NSCollectionLayoutGroup.horizontal(
+                        layoutSize: .init(
+                            widthDimension: .fractionalWidth(1.0),
+                            heightDimension: .absolute(groupHeight)
+                        ),
+                        subitems: [item]
+                    )
+                    
+                    group.interItemSpacing = .fixed(-5)
+                    
+                    let section = NSCollectionLayoutSection(group: group)
+                    
+                    section.orthogonalScrollingBehavior = .continuous
+                    
+                    return section
+                }
             
             } else if sectionNumber == 2 {
                 let itemSize = NSCollectionLayoutSize(

--- a/Terning-iOS/Terning-iOS/Resource/Utils/CompositionalLayout.swift
+++ b/Terning-iOS/Terning-iOS/Resource/Utils/CompositionalLayout.swift
@@ -119,7 +119,7 @@ struct CompositionalLayout {
                 )
                 
                 let group = NSCollectionLayoutGroup.horizontal(
-                    layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .estimated(48)),
+                    layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .estimated(40)),
                     subitems: [item]
                 )
                 
@@ -137,7 +137,7 @@ struct CompositionalLayout {
                     )
                 )
                 
-                item.contentInsets.leading = 12
+                item.contentInsets.trailing = 12
                 
                 let groupHeight: CGFloat = 116
                 
@@ -154,7 +154,7 @@ struct CompositionalLayout {
                 let section = NSCollectionLayoutSection(group: group)
                 
                 section.orthogonalScrollingBehavior = .continuous
-                section.contentInsets = .init(top: 0, leading: 12, bottom: 28, trailing: 0)
+                section.contentInsets = .init(top: 0, leading: 24, bottom: 20, trailing: 0)
                 
                 return section
             

--- a/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/IsScrapInfoViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/IsScrapInfoViewCell.swift
@@ -106,7 +106,6 @@ extension IsScrapInfoViewCell {
             companyLabelStack,
             dDayView,
             dDayLabel
-            
         )
     }
     

--- a/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/IsScrapInfoViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/IsScrapInfoViewCell.swift
@@ -120,13 +120,13 @@ extension IsScrapInfoViewCell {
         colorMark.snp.makeConstraints {
             $0.verticalEdges.equalTo(scrapAndDeadlineCard)
             $0.leading.equalTo(scrapAndDeadlineCard)
-            $0.width.equalTo(8)
+            $0.width.equalTo(8.adjusted)
         }
         
         cardLabel.snp.makeConstraints {
             $0.top.equalTo(scrapAndDeadlineCard.snp.top).offset(16)
             $0.leading.equalTo(colorMark.snp.trailing).offset(12)
-            $0.width.equalTo(214)
+            $0.width.equalTo(214.adjusted)
         }
         
         companyLabelStack.snp.makeConstraints {
@@ -135,14 +135,14 @@ extension IsScrapInfoViewCell {
         }
         
         companyImageView.snp.makeConstraints {
-            $0.height.width.equalTo(32)
+            $0.height.width.equalTo(32.adjustedH)
         }
         
         dDayView.snp.makeConstraints {
             $0.top.equalTo(cardLabel.snp.bottom).offset(28)
             $0.trailing.equalTo(scrapAndDeadlineCard.snp.trailing).inset(12)
-            $0.height.equalTo(20)
-            $0.width.equalTo(43)
+            $0.height.equalTo(20.adjustedH)
+            $0.width.equalTo(43.adjusted)
         }
 
         dDayLabel.snp.makeConstraints {

--- a/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/IsScrapInfoViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/IsScrapInfoViewCell.swift
@@ -41,8 +41,44 @@ final class IsScrapInfoViewCell: UICollectionViewCell {
         font: .button3,
         textAlignment: .left
     ).then {
-        $0.numberOfLines = 3
+        $0.numberOfLines = 2
         $0.isUserInteractionEnabled = true
+    }
+    
+    private let companyImageView = UIImageView().then {
+        $0.image = UIImage(resource: .default)
+        $0.clipsToBounds = true
+        $0.makeBorder(width: 1, color: .grey150, cornerRadius: 32/2)
+    }
+    
+    private var companyName = LabelFactory.build(
+        text: "기업 이름",
+        font: .button5,
+        textColor: .grey400,
+        textAlignment: .left
+    )
+    
+    private lazy var companyLabelStack = UIStackView(
+        arrangedSubviews: [
+            companyImageView,
+            companyName
+        ]
+    ).then {
+        $0.axis = .horizontal
+        $0.spacing = 6
+        $0.distribution = .equalSpacing
+        $0.alignment = .center
+    }
+    
+    private var dDayLabel = LabelFactory.build(
+        text: "D-0",
+        font: .body4,
+        textColor: .terningMain
+    )
+    
+    private var dDayView = UIView().then {
+        $0.backgroundColor = .terningSub3
+        $0.layer.cornerRadius = 5
     }
     
     // MARK: - LifeCycles
@@ -66,7 +102,11 @@ extension IsScrapInfoViewCell {
         contentView.addSubviews(
             scrapAndDeadlineCard,
             colorMark,
-            cardLabel
+            cardLabel,
+            companyLabelStack,
+            dDayView,
+            dDayLabel
+            
         )
     }
     
@@ -74,7 +114,7 @@ extension IsScrapInfoViewCell {
         scrapAndDeadlineCard.snp.makeConstraints {
             $0.verticalEdges.equalToSuperview()
             $0.trailing.equalToSuperview()
-            $0.leading.equalToSuperview().offset(8)
+            $0.leading.equalToSuperview()
         }
         
         colorMark.snp.makeConstraints {
@@ -84,22 +124,52 @@ extension IsScrapInfoViewCell {
         }
         
         cardLabel.snp.makeConstraints {
-            $0.bottom.equalTo(scrapAndDeadlineCard.snp.bottom).inset(8)
-            $0.leading.equalTo(colorMark.snp.trailing).offset(8)
-            $0.width.equalTo(115)
+            $0.top.equalTo(scrapAndDeadlineCard.snp.top).offset(16)
+            $0.leading.equalTo(colorMark.snp.trailing).offset(12)
+            $0.width.equalTo(214)
+        }
+        
+        companyLabelStack.snp.makeConstraints {
+            $0.top.equalTo(cardLabel.snp.bottom).offset(22)
+            $0.leading.equalTo(colorMark.snp.trailing).offset(12)
+        }
+        
+        companyImageView.snp.makeConstraints {
+            $0.height.width.equalTo(32)
+        }
+        
+        dDayView.snp.makeConstraints {
+            $0.top.equalTo(cardLabel.snp.bottom).offset(28)
+            $0.trailing.equalTo(scrapAndDeadlineCard.snp.trailing).inset(12)
+            $0.height.equalTo(20)
+            $0.width.equalTo(43)
+        }
+
+        dDayLabel.snp.makeConstraints {
+            $0.centerX.equalTo(dDayView)
+            $0.centerY.equalTo(dDayView)
         }
     }
     
     // MARK: - Methods
     
     func bindData(model: ScrapedAndDeadlineModel) {
+        if let range = model.title.range(of: "\\[(.*?)\\]", options: .regularExpression) {
+            let extractedCompanyName = String(model.title[range]).replacingOccurrences(of: "[", with: "").replacingOccurrences(of: "]", with: "")
+            
+            self.companyName.text = extractedCompanyName
+        }
+        
+        self.companyImageView.setImage(with: model.companyImage, placeholder: "placeholder_image")
+        self.dDayLabel.text = model.dDay
+        self.cardLabel.text = model.title
+        self.colorMark.backgroundColor = UIColor(hex: model.color)
+        
         self.internshipAnnouncementId = model.internshipAnnouncementId
         self.companyImage = model.companyImage
         self.dDay = model.dDay
-        self.cardLabel.text = model.title
         self.workingPeriod = model.workingPeriod
         self.isScrapped = model.isScrapped
-        self.colorMark.backgroundColor = UIColor(hex: model.color)
         self.deadline = model.deadline
         self.startYearMonth = model.startYearMonth
     }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/NonScrapInfoCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/NonScrapInfoCell.swift
@@ -61,7 +61,7 @@ extension NonScrapInfoCell {
     private func setLayout() {
         internshipScrapedStatus.snp.makeConstraints {
             $0.top.leading.bottom.equalToSuperview()
-            $0.trailing.equalToSuperview().offset(199)
+            $0.trailing.equalToSuperview()
         }
         
         nonTodayDeadlineImage.snp.makeConstraints {

--- a/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/ScrapInfoHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/ScrapInfoHeaderCell.swift
@@ -48,7 +48,7 @@ extension ScrapInfoHeaderCell {
     private func setLayout() {
         titleLabel.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.leading.equalToSuperview().offset(18.adjusted)
+            $0.leading.equalToSuperview().offset(24)
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/ScrapInfoHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/ScrapInfoHeaderCell.swift
@@ -48,7 +48,7 @@ extension ScrapInfoHeaderCell {
     private func setLayout() {
         titleLabel.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.leading.equalToSuperview().offset(24.adjusted)
+            $0.leading.equalToSuperview().offset(18.adjusted)
         }
     }
 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #131

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
### 1. 곧 마감되는 공고카드의 바인딩 함수를 바꿔주었습니다. (2024.09.07)
* UI컴포넌트를 추가하면서 바인딩해야하는 값들이 있어 그 부분과 관련해서 수정하였습니다.,

### 2. 곧 마감되는 공고카드에 해당되는 컴포지셔널 레이아웃 코드를 수정했습니다. (2024.09.07)
* 높이와 너비 정도 수정되었고 inset과 같은 값을 수정했습니다. 
* 추가적으로 이렇게 레이아웃을 잡을 경우 곧 마감되는 공고카드가 없을 때 뜨는 화면의 레이아웃이 잘 잡히지 않을 것 같아서 
분기처리를 통해서 이를 위한 레이아웃을 따로 잡아줘야하지 않을까 하는 생각입니다. 

### 3. 컬러 에셋을 추가했습니다. (2024.09.07)
* dDay 라벨의 배경이 되는 라운딩된 둥근 사각형의 색상이 컬러 에셋에 없어서 추가해주었습니다.
* 추가된 컬러의 이름은 terning_sub3입니다. 

|    내용    |   이미지  |
|:---------------:|:------------------:|
| 컬러 추가한 부분 | <img width="66" alt="스크린샷 2024-09-07 오후 2 40 41" src="https://github.com/user-attachments/assets/3a904fab-f8bb-40b2-b67b-12c9d6bfc6e8"> |

### 🔥 4. 곧 마감되는 공고카드가 없을 때의 레이아웃 분기처리 (2024.09.08)
* 곧 마감되는 공고카드가 없을 때의 레이아웃 분기처리를 해주었습니다.
<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

### 1. 변경된 바인딩 함수입니다. (2024.09.07)
* 서버에서 따로 기업의 이름을 보내주지 않는데 이 부분은 정규식을 사용해서 
공고 카드의 title 데이터에서 대괄호 안의 내용을 추출하도록 했습니다.

|    내용    |   이미지  |
|:---------------:|:------------------:|
| 기업 이름 들어가는 부분 | <img width="97" alt="스크린샷 2024-09-07 오후 2 44 09" src="https://github.com/user-attachments/assets/77b185ac-6963-46d7-b368-fff94b5173e1"> |

```swift
func bindData(model: ScrapedAndDeadlineModel) {
    if let range = model.title.range(of: "\\[(.*?)\\]", options: .regularExpression) {
        let extractedCompanyName = String(model.title[range]).replacingOccurrences(of: "[", with: "").replacingOccurrences(of: "]", with: "")
            
        self.companyName.text = extractedCompanyName
    }
        
    self.companyImageView.setImage(with: model.companyImage, placeholder: "placeholder_image")
    self.dDayLabel.text = model.dDay
    self.cardLabel.text = model.title
    self.colorMark.backgroundColor = UIColor(hex: model.color)
        
    self.internshipAnnouncementId = model.internshipAnnouncementId
    self.companyImage = model.companyImage
    self.dDay = model.dDay
    self.workingPeriod = model.workingPeriod
    self.isScrapped = model.isScrapped
    self.deadline = model.deadline
    self.startYearMonth = model.startYearMonth
}
```

### 2. 컴포지셔널 레이아웃 코드 입니다. (2024.09.07)
* 여기에서 포인트는 기존에는 깡값을 사용했다면 비율을 계산한 값을 변수에 넣어서 그 변수를 넣어줬다는 점입니다.
``` swift
let itemWidth: CGFloat = 246/375
 let item = NSCollectionLayoutItem(
    layoutSize: .init(
        widthDimension: .fractionalWidth(itemWidth),
        heightDimension: .fractionalHeight(1)
    )
)
```

### 🔥 3. 컴포지셔널 레이아웃 분기 처리한 코드입니다. (2024.09.08)
* 곧 마감되는 공고카드에서 어떤 셀이 뜰지에 대해서 `todayDeadlineLists`의 값이 비어있는지 아닌지에 따라서 정하고 있길래 
`NewHomeViewController`의 `todayDeadlineLists`에 접근해 분기처리를 해주었습니다.
(이거 코드 공백 한번에 없앨 수 있는 방법 좀 알려주세욥... 원래는 일일이 다 지웠는데 이건 코드길이가 길어서 엄두가 안나요...)
``` swift
} else if sectionNumber == 1 {
                
                let HomeVC = NewHomeViewController()
                
                if HomeVC.todayDeadlineLists.isEmpty {
                    let itemWidth: CGFloat = 327.adjusted
                    
                    let item = NSCollectionLayoutItem(
                        layoutSize: .init(
                            widthDimension: .absolute(itemWidth),
                            heightDimension: .fractionalHeight(1)
                        )
                    )
                    
                    let groupHeight: CGFloat = 116.adjustedH
                    
                    let group = NSCollectionLayoutGroup.horizontal(
                        layoutSize: .init(
                            widthDimension: .fractionalWidth(1.0),
                            heightDimension: .absolute(groupHeight)
                        ), subitems: [item]
                    )
                    
                    let section = NSCollectionLayoutSection(group: group)
                    section.contentInsets = .init(top: 0, leading: 24, bottom: 20, trailing: 0)
                    
                    return section
                    
                } else {
                    let itemWidth: CGFloat = 246.adjusted
                    
                    let item = NSCollectionLayoutItem(
                        layoutSize: .init(
                            widthDimension: .absolute(itemWidth),
                            heightDimension: .fractionalHeight(1)
                        )
                    )
                    
                    item.contentInsets.trailing = 12
                    
                    let groupHeight: CGFloat = 116.adjustedH
                    
                    let group = NSCollectionLayoutGroup.horizontal(
                        layoutSize: .init(
                            widthDimension: .fractionalWidth(1.0),
                            heightDimension: .absolute(groupHeight)
                        ),
                        subitems: [item]
                    )
                    
                    group.interItemSpacing = .fixed(-5)
                    
                    let section = NSCollectionLayoutSection(group: group)
                    
                    section.orthogonalScrollingBehavior = .continuous
                    
                    return section
                }
```
<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.

-->

|    구현 내용    |   이미지  |
|:---------------:|:------------------:|
| 곧 마감되는 공고 카드(있을 때) | <img src = "https://github.com/user-attachments/assets/f4644d52-02cb-4ab5-bfd0-8393a49f9e04" width = "40%" height = "40%"> |
| 곧 마감되는 공고 카드(없을 때) | <img src = "https://github.com/user-attachments/assets/281e30f2-d519-41bd-b664-89741a24348e" width = "40%" height = "40%"> | 
<br/>