### PR TITLE
[Fix] #125 - 탐색뷰 관련 UI 수정 반영했습니다. 

### DIFF
--- a/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/InavailableFilterView.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/InavailableFilterView.swift
@@ -15,7 +15,7 @@ class InavailableFilterView: UICollectionViewCell {
     // MARK: - UIComponents
     
     private let inavailableIcon = UIImageView().then {
-        $0.image = UIImage(systemName: "exclamationmark.circle.fill")
+        $0.image = .imgNonCardViewInfo
         $0.tintColor = .grey200
     }
     
@@ -25,7 +25,6 @@ class InavailableFilterView: UICollectionViewCell {
         textColor: .grey400,
         textAlignment: .center
     ).then {
-        
         $0.numberOfLines = 2
     }
     
@@ -55,15 +54,14 @@ extension InavailableFilterView {
     
     private func setLayout() {
         inavailableIcon.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(80.adjusted)
-            $0.centerX.equalToSuperview()
-            $0.height.equalTo(36)
-            $0.width.equalTo(36)
+            $0.top.equalToSuperview().offset(46.adjustedH)
+            $0.horizontalEdges.equalToSuperview().inset(24.adjusted)
+            $0.height.equalTo(222.adjustedH)
         }
         
         inavailableLabel.snp.makeConstraints {
-            $0.top.equalTo(inavailableIcon.snp.bottom).offset(9)
-            $0.centerX.equalToSuperview()
+            $0.top.equalTo(inavailableIcon.snp.bottom).offset(2.adjustedH)
+            $0.horizontalEdges.equalToSuperview().inset(29.adjusted)
         }
     }
 }
@@ -90,9 +88,9 @@ extension InavailableFilterView {
         
         inavailableLabel.attributedText = attributedString
         
-        inavailableLabel.snp.updateConstraints {
-            $0.top.equalTo(inavailableIcon.snp.bottom).offset(16)
-            $0.centerX.equalToSuperview()
+        inavailableLabel.snp.makeConstraints {
+            $0.top.equalTo(inavailableIcon.snp.bottom).offset(2.adjustedH)
+            $0.horizontalEdges.equalToSuperview().inset(29.adjusted)
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/InavailableFilterView.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/NewHome/Cell/InavailableFilterView.swift
@@ -15,7 +15,7 @@ class InavailableFilterView: UICollectionViewCell {
     // MARK: - UIComponents
     
     private let inavailableIcon = UIImageView().then {
-        $0.image = .imgNonCardViewInfo
+        $0.image = UIImage(systemName: "exclamationmark.circle.fill")
         $0.tintColor = .grey200
     }
     
@@ -25,6 +25,7 @@ class InavailableFilterView: UICollectionViewCell {
         textColor: .grey400,
         textAlignment: .center
     ).then {
+        
         $0.numberOfLines = 2
     }
     
@@ -54,14 +55,15 @@ extension InavailableFilterView {
     
     private func setLayout() {
         inavailableIcon.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(46.adjustedH)
-            $0.horizontalEdges.equalToSuperview().inset(24.adjusted)
-            $0.height.equalTo(222.adjustedH)
+            $0.top.equalToSuperview().offset(80.adjusted)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(36)
+            $0.width.equalTo(36)
         }
         
         inavailableLabel.snp.makeConstraints {
-            $0.top.equalTo(inavailableIcon.snp.bottom).offset(2.adjustedH)
-            $0.horizontalEdges.equalToSuperview().inset(29.adjusted)
+            $0.top.equalTo(inavailableIcon.snp.bottom).offset(9)
+            $0.centerX.equalToSuperview()
         }
     }
 }
@@ -88,9 +90,9 @@ extension InavailableFilterView {
         
         inavailableLabel.attributedText = attributedString
         
-        inavailableLabel.snp.makeConstraints {
-            $0.top.equalTo(inavailableIcon.snp.bottom).offset(2.adjustedH)
-            $0.horizontalEdges.equalToSuperview().inset(29.adjusted)
+        inavailableLabel.snp.updateConstraints {
+            $0.top.equalTo(inavailableIcon.snp.bottom).offset(16)
+            $0.centerX.equalToSuperview()
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Search/Cell/RecommendCollectionViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Search/Cell/RecommendCollectionViewCell.swift
@@ -82,19 +82,19 @@ extension RecommendCollectionViewCell {
     private func setLayout() {
         recommendImageView.snp.makeConstraints {
             $0.top.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(70)
+            $0.height.equalTo(70.adjustedH)
         }
         
         underLineView.snp.makeConstraints {
             $0.bottom.equalTo(recommendImageView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(2)
+            $0.height.equalTo(2.adjustedH)
         }
         
         descriptionLabel.snp.makeConstraints {
             $0.top.equalTo(underLineView.snp.bottom).offset(8.adjustedH)
             $0.horizontalEdges.equalToSuperview().inset(8.adjusted)
-            $0.bottom.equalToSuperview().inset(7.adjustedH)
+            $0.bottom.greaterThanOrEqualToSuperview().inset(7.adjustedH)
             $0.height.equalTo(51.adjustedH)
         }
     }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Search/Cell/RecommendCollectionViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Search/Cell/RecommendCollectionViewCell.swift
@@ -15,7 +15,8 @@ final class RecommendCollectionViewCell: UICollectionViewCell {
     // MARK: - UI Components
     
     private let recommendImageView = UIImageView().then {
-        $0.contentMode = .scaleAspectFill
+        $0.contentMode = .scaleAspectFit
+        $0.backgroundColor = .white
         $0.layer.masksToBounds = true
         $0.layer.cornerRadius = 5
         $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
@@ -85,16 +86,16 @@ extension RecommendCollectionViewCell {
         }
         
         underLineView.snp.makeConstraints {
-            $0.top.equalTo(recommendImageView.snp.bottom)
+            $0.bottom.equalTo(recommendImageView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(2)
         }
         
         descriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(underLineView.snp.bottom).offset(8)
-            $0.horizontalEdges.equalToSuperview().inset(8)
-            $0.bottom.equalToSuperview().inset(7)
-            $0.height.equalTo(51)
+            $0.top.equalTo(underLineView.snp.bottom).offset(8.adjustedH)
+            $0.horizontalEdges.equalToSuperview().inset(8.adjusted)
+            $0.bottom.equalToSuperview().inset(7.adjustedH)
+            $0.height.equalTo(51.adjustedH)
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Search/Cell/SearchCollectionViewHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Search/Cell/SearchCollectionViewHeaderCell.swift
@@ -27,16 +27,12 @@ final class SearchCollectionViewHeaderCell: UICollectionReusableView {
         text: "요즘 대학생들에게 인기 있는 공고",
         font: .title1,
         textColor: .terningBlack,
-        textAlignment: .left
+        textAlignment: .left,
+        lineSpacing: 1.2
     )
     
-    private let underLineView = UIView().then {
-        $0.backgroundColor = .grey100
-        $0.isHidden = true
-    }
-    
     private let subTitleLabel = LabelFactory.build(
-        font: .title5,
+        font: .body3,
         textColor: .grey400,
         textAlignment: .left,
         lineSpacing: 1.2,
@@ -60,7 +56,7 @@ final class SearchCollectionViewHeaderCell: UICollectionReusableView {
 
 extension SearchCollectionViewHeaderCell {
     private func setUI() {
-        self.addSubviews(titleLabel, underLineView, subTitleLabel)
+        self.addSubviews(titleLabel, subTitleLabel)
     }
     
     private func setLayout(_ type: SearchHeaderType) {
@@ -78,30 +74,23 @@ extension SearchCollectionViewHeaderCell {
 extension SearchCollectionViewHeaderCell {
     private func setMainLayout() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(16)
+            $0.top.equalToSuperview().inset(20.adjustedH)
             $0.horizontalEdges.equalToSuperview()
         }
         subTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(3)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(4.adjustedH)
             $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(13)
+            $0.bottom.equalToSuperview().inset(12.adjustedH)
         }
     }
     
     private func setSubLayout() {
         titleLabel.isHidden = true
-        underLineView.isHidden = false
-        
-        underLineView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(16)
-            $0.leading.equalToSuperview().inset(-22)
-            $0.trailing.equalToSuperview()
-            $0.height.equalTo(4)
-        }
+
         subTitleLabel.snp.remakeConstraints {
-            $0.top.equalTo(underLineView.snp.bottom).offset(12)
+            $0.top.equalToSuperview().offset(32.adjustedH)
             $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(13)
+            $0.bottom.equalToSuperview().inset(12.adjustedH)
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Search/View/SearchView.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Search/View/SearchView.swift
@@ -42,7 +42,12 @@ final class SearchView: UIView {
     
     let pageControl = UIPageControl().then {
         $0.currentPage = 0
-        $0.pageIndicatorTintColor = .white
+        $0.pageIndicatorTintColor = UIColor(
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 0.5
+        )
         $0.currentPageIndicatorTintColor = .terningMain
         $0.isUserInteractionEnabled = false
     }
@@ -89,24 +94,24 @@ extension SearchView {
     private func setLayout() {
         navigationView.snp.makeConstraints {
             $0.top.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(52)
+            $0.height.equalTo(52.adjustedH)
         }
         logoImageView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(15)
-            $0.leading.equalToSuperview().inset(21)
-            $0.height.equalTo(27)
-            $0.width.equalTo(113)
+            $0.top.equalToSuperview().inset(8.adjustedH)
+            $0.leading.equalToSuperview().inset(21.adjusted)
+            $0.height.equalTo(27.adjustedH)
+            $0.width.equalTo(113.adjusted)
         }
         searchView.snp.makeConstraints {
-            $0.top.equalTo(navigationView.snp.bottom).offset(6)
-            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.top.equalTo(navigationView.snp.bottom).offset(8.adjustedH)
+            $0.horizontalEdges.equalToSuperview().inset(24.adjusted)
         }
         collectionView.snp.makeConstraints {
-            $0.top.equalTo(searchView.snp.bottom).offset(16)
+            $0.top.equalTo(searchView.snp.bottom).offset(12.adjustedH)
             $0.horizontalEdges.bottom.equalToSuperview()
         }
         pageControl.snp.makeConstraints {
-            $0.top.equalTo(collectionView.snp.top).offset(78)
+            $0.top.equalTo(collectionView.snp.top).offset(84.adjustedH)
             $0.centerX.equalToSuperview()
         }
     }
@@ -118,42 +123,43 @@ extension SearchView {
     private static func createAdvertisementSection(using environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(108)
+            heightDimension: .absolute(108.adjustedH)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(108)
+            heightDimension: .absolute(108.adjustedH)
         )
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPaging
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 7, trailing: 0)
         
         return section
     }
     
     private static func createRecommendSection() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(140),
-            heightDimension: .absolute(136)
+            widthDimension: .absolute(140.adjusted),
+            heightDimension: .absolute(136.adjustedH)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 12)
+        item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 12.adjusted)
         
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(140),
-            heightDimension: .absolute(136)
+            widthDimension: .absolute(140.adjusted),
+            heightDimension: .absolute(136.adjustedH)
         )
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .continuous
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 24.adjusted, bottom: 0, trailing: 0)
         
-        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                                heightDimension: .estimated(63))
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(63.adjustedH)
+        )
         let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerSize,
             elementKind: UICollectionView.elementKindSectionHeader,

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Search/ViewController/SearchViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Search/ViewController/SearchViewController.swift
@@ -237,13 +237,13 @@ extension SearchViewController: UICollectionViewDelegate {
         case .viewsNum:
             headerView.bind(
                 title: "요즘 대학생들에게 인기 있는 공고",
-                subTitle: "지금 조회수가 많은 공고들이에요",
+                subTitle: "이번 주 가장 많이 조회한 공고에요",
                 type: .main
             )
         case .scrapsNum:
             headerView.bind(
                 title: nil,
-                subTitle: "지금 스크랩수가 많은 공고들이에요",
+                subTitle: "이번 주 가장 많이 스크랩 한 공고에요",
                 type: .sub
             )
         }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/GraphicCollectionViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/GraphicCollectionViewCell.swift
@@ -14,7 +14,6 @@ final class GraphicCollectionViewCell: UICollectionViewCell {
     // MARK: - UI Components
     
     private let imageView = UIImageView().then {
-        $0.image = .imgSearch
         $0.contentMode = .scaleAspectFill
         $0.layer.masksToBounds = true
     }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/SortHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/SortHeaderCell.swift
@@ -11,26 +11,45 @@ import RxSwift
 
 import SnapKit
 
-final class SortHeaderCell: UICollectionReusableView {
+final class SortHeaderCell: UICollectionViewCell {
+    
+    // MARK: - Properties
+    
+    let sortButtonTapSubject = PublishSubject<Void>()
+    
+    var disposeBag = DisposeBag()
     
     // MARK: - UIComponents
-
-    var sortButton = CustomSortButton()
-    var sortBySubject = PublishSubject<String>()
     
-    private let disposeBag = DisposeBag()
+    private let searchResultCountLabel = LabelFactory.build(
+        text: "총 0개의 공고가 있어요",
+        font: .detail1,
+        textColor: .grey400,
+        textAlignment: .left,
+        lineSpacing: 1.2,
+        characterSpacing: 0.002
+    )
+    
+    var sortButton = CustomSortButton()
     
     // MARK: - Init
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        
         setHierarchy()
         setLayout()
-        bind()
+        bindViewModel()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+        bindViewModel()
     }
 }
 
@@ -38,20 +57,70 @@ final class SortHeaderCell: UICollectionReusableView {
 
 extension SortHeaderCell {
     func setHierarchy() {
-        addSubview(sortButton)
+        addSubviews(
+            searchResultCountLabel,
+            sortButton
+        )
     }
     
     func setLayout() {
+        searchResultCountLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(24.adjusted)
+            $0.top.equalToSuperview().inset(5.adjustedH)
+            $0.trailing.equalTo(sortButton.snp.leading).inset(10.adjusted)
+        }
         sortButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(22)
+            $0.trailing.equalToSuperview().inset(22.adjusted)
             $0.centerY.equalToSuperview()
         }
     }
-    
-    private func bind() {
+}
+
+extension SortHeaderCell {
+    private func bindViewModel() {
         sortButton.rx.tap
-            .map { "정렬기준" }
-            .bind(to: sortBySubject)
+            .bind(to: sortButtonTapSubject)
             .disposed(by: disposeBag)
+    }
+}
+
+extension SortHeaderCell {
+    func bind(with count: Int) {
+        var countString = "\(count)"
+        
+        if countString.count > 12 {
+            let startIndex = countString.startIndex
+            let endIndex = countString.index(startIndex, offsetBy: 10)
+            countString = String(countString[startIndex..<endIndex]) + "..."
+        }
+        
+        let fullText = "총 \(countString)개의 공고가 있어요"
+        
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 1.2
+        
+        let attributedText = NSMutableAttributedString(
+            string: fullText,
+            attributes: [
+                .font: UIFont.detail1,
+                .foregroundColor: UIColor.grey400,
+                .kern: 0.002,
+                .paragraphStyle: paragraphStyle
+            ]
+        )
+        
+        let range = (fullText as NSString).range(of: countString)
+        attributedText.addAttributes([
+            .font: UIFont.body3,
+            .foregroundColor: UIColor.terningMain,
+            .kern: 0.002,
+            .paragraphStyle: paragraphStyle
+        ], range: range)
+        
+        searchResultCountLabel.attributedText = attributedText
+    }
+    
+    func setSortButtonTitle(_ title: String) {
+        sortButton.setTitle(title, for: .normal)
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/SortHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/SortHeaderCell.swift
@@ -58,18 +58,15 @@ final class SortHeaderCell: UICollectionReusableView {
 
 extension SortHeaderCell {
     func setHierarchy() {
+        backgroundColor = .white
         addSubviews(
-            gradientView,
             searchResultCountLabel,
-            sortButton
+            sortButton,
+            gradientView
         )
     }
     
     func setLayout() {
-        gradientView.snp.makeConstraints {
-            $0.top.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(28.adjustedH)
-        }
         searchResultCountLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(24.adjusted)
             $0.top.equalToSuperview().inset(5.adjustedH)
@@ -78,6 +75,11 @@ extension SortHeaderCell {
         sortButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(22.adjusted)
             $0.centerY.equalToSuperview()
+        }
+        gradientView.snp.makeConstraints {
+            $0.top.equalTo(searchResultCountLabel.snp.bottom).offset(3.adjustedH)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(28.adjustedH)
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/SortHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/SortHeaderCell.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 import SnapKit
 
-final class SortHeaderCell: UICollectionViewCell {
+final class SortHeaderCell: UICollectionReusableView {
     
     // MARK: - Properties
     
@@ -20,6 +20,7 @@ final class SortHeaderCell: UICollectionViewCell {
     var disposeBag = DisposeBag()
     
     // MARK: - UIComponents
+    private let gradientView = GradientLayerView()
     
     private let searchResultCountLabel = LabelFactory.build(
         text: "총 0개의 공고가 있어요",
@@ -58,12 +59,17 @@ final class SortHeaderCell: UICollectionViewCell {
 extension SortHeaderCell {
     func setHierarchy() {
         addSubviews(
+            gradientView,
             searchResultCountLabel,
             sortButton
         )
     }
     
     func setLayout() {
+        gradientView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(28.adjustedH)
+        }
         searchResultCountLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(24.adjusted)
             $0.top.equalToSuperview().inset(5.adjustedH)

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/View/SearchResultView.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/View/SearchResultView.swift
@@ -38,6 +38,8 @@ final class SearchResultView: UIView {
         switch section {
         case .graphic:
             return SearchResultView.createGraphicSection()
+        case .sort:
+            return SearchResultView.createSortSection()
         case .search:
             return SearchResultView.createSearchSection()
         case .noSearch:
@@ -81,8 +83,7 @@ extension SearchResultView {
         )
         collectionView.register(
             SortHeaderCell.self,
-            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
-            withReuseIdentifier: SortHeaderCell.className
+            forCellWithReuseIdentifier: SortHeaderCell.className
         )
         
         collectionView.backgroundColor = .white
@@ -169,6 +170,24 @@ extension SearchResultView {
         return section
     }
     
+    private static func createSortSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(28.adjustedH)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(28.adjustedH)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+      
+        let section = NSCollectionLayoutSection(group: group)
+        
+        return section
+    }
+    
     private static func createSearchSection() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
@@ -191,13 +210,13 @@ extension SearchResultView {
     private static func createNoSearchSection() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(100)
+            heightDimension: .absolute(266.adjustedH)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(100)
+            heightDimension: .absolute(266.adjustedH)
         )
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/View/SearchResultView.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/View/SearchResultView.swift
@@ -15,7 +15,7 @@ final class SearchResultView: UIView {
     
     // MARK: - Properties
     
-    var SearchResult: [SearchResult]?
+    var searchResult: [SearchResult]?
     var sortBySubject = PublishSubject<String>()
     
     // MARK: - UI Components
@@ -33,20 +33,19 @@ final class SearchResultView: UIView {
         $0.numberOfLines = 2
     }
     
-    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewCompositionalLayout { (sectionIndex, _) -> NSCollectionLayoutSection? in
-        guard let section = SearchResultType(rawValue: sectionIndex) else { return nil }
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewCompositionalLayout { [weak self] (sectionIndex, _) -> NSCollectionLayoutSection? in
+        guard let section = SearchResultType(rawValue: sectionIndex), let self = self else { return nil }
+        
         switch section {
         case .graphic:
             return SearchResultView.createGraphicSection()
-        case .sort:
-            return SearchResultView.createSortSection()
         case .search:
-            return SearchResultView.createSearchSection()
+            return SearchResultView.createSearchSection(hasResults: self.searchResult?.count ?? 0 > 0)
         case .noSearch:
-            return SearchResultView.createNoSearchSection()
+            return SearchResultView.createNoSearchSection(hasResults: self.searchResult?.count ?? 0 == 0)
         }
     })
-    
+
     // MARK: - init
     
     override init(frame: CGRect) {
@@ -83,9 +82,9 @@ extension SearchResultView {
         )
         collectionView.register(
             SortHeaderCell.self,
-            forCellWithReuseIdentifier: SortHeaderCell.className
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: SortHeaderCell.className
         )
-        
         collectionView.backgroundColor = .white
     }
     
@@ -170,25 +169,7 @@ extension SearchResultView {
         return section
     }
     
-    private static func createSortSection() -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(28.adjustedH)
-        )
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        
-        let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(28.adjustedH)
-        )
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-      
-        let section = NSCollectionLayoutSection(group: group)
-        
-        return section
-    }
-    
-    private static func createSearchSection() -> NSCollectionLayoutSection {
+    private static func createSearchSection(hasResults: Bool) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .estimated(116)
@@ -204,10 +185,26 @@ extension SearchResultView {
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 0, trailing: 0)
         
+        if hasResults {
+            let headerSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(28.adjustedH)
+            )
+            let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
+                layoutSize: headerSize,
+                elementKind: UICollectionView.elementKindSectionHeader,
+                alignment: .top
+            )
+            sectionHeader.pinToVisibleBounds = true
+            section.boundarySupplementaryItems = [sectionHeader]
+        } else {
+            section.boundarySupplementaryItems = []
+        }
+        
         return section
     }
 
-    private static func createNoSearchSection() -> NSCollectionLayoutSection {
+    private static func createNoSearchSection(hasResults: Bool) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .absolute(266.adjustedH)
@@ -221,6 +218,22 @@ extension SearchResultView {
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         
         let section = NSCollectionLayoutSection(group: group)
+        
+        if hasResults {
+            let headerSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(28.adjustedH)
+            )
+            let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
+                layoutSize: headerSize,
+                elementKind: UICollectionView.elementKindSectionHeader,
+                alignment: .top
+            )
+            sectionHeader.pinToVisibleBounds = true
+            section.boundarySupplementaryItems = [sectionHeader]
+        } else {
+            section.boundarySupplementaryItems = []
+        }
         
         return section
     }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -125,12 +125,7 @@ extension SearchResultViewController {
             })
 
         let searchTrigger = Observable.merge(searchChanged, sortChanged, pageChanged.map { _ in () })
-            .withLatestFrom(Observable.combineLatest(keyword, sortBySubject)) { _, combinedValues in
-                return combinedValues
-            }
-            .map { (keyword, _) -> String in
-                return keyword
-            }
+            .withLatestFrom(keyword)
             .do(onNext: { _ in
                 if firstSearch {
                     firstSearch = false

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -464,10 +464,9 @@ extension SearchResultViewController: SortSettingButtonProtocol {
     func didSelectSortingOption(_ option: SortingOptions) {
         sortBySubject.onNext(option.apiValue)
         
-        if let sortHeader = rootView.collectionView.supplementaryView(
-            forElementKind: UICollectionView.elementKindSectionHeader,
-            at: IndexPath(item: 0, section: 0)
-        ) as? SortHeaderCell {
+        let visibleHeaders = rootView.collectionView.visibleSupplementaryViews(ofKind: UICollectionView.elementKindSectionHeader)
+
+        if let sortHeader = visibleHeaders.first as? SortHeaderCell {
             sortHeader.setSortButtonTitle(option.title)
         }
     }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
@@ -20,6 +20,7 @@ final class SearchResultViewModel: ViewModelType {
     
     struct Input {
         let keyword: Observable<String>
+        let sortTap: Observable<Void>
         let sortBy: Observable<String>
         let page: Observable<Int>
         let size: Observable<Int>
@@ -29,69 +30,98 @@ final class SearchResultViewModel: ViewModelType {
     // MARK: - Output
     
     struct Output {
-        let SearchResult: Driver<[SearchResult]>
+        let showSortBottom: Driver<Void>
+        let searchResults: Driver<[SearchResult]>
         let keyword: Driver<String>
+        let totalPages: Driver<Int>
+        let hasNextPage: Driver<Bool>
     }
     
     // MARK: - Transform
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
-        let SearchResult = input.searchTrigger
+        let searchResponse = input.searchTrigger
+            .do(onNext: { print("searchTrigger 발생") }) 
             .withLatestFrom(Observable.combineLatest(input.keyword, input.sortBy, input.page, input.size))
             .flatMapLatest { keyword, sortBy, page, size in
-                self.fetchJobCards(keyword: keyword, sortBy: sortBy, page: page, size: size)
-                    .catchAndReturn([])
+                print("Fetching job cards with keyword: \(keyword), sortBy: \(sortBy), page: \(page), size: \(size)")
+                
+                return self.fetchJobCards(keyword: keyword, sortBy: sortBy, page: page, size: size)
+                    .catchAndReturn(SearchResultModel(totalPages: 0, hasNext: false, announcements: []))
             }
+            .do(onNext: { response in
+                print("Search response received: \(response)")
+            })
+            .share(replay: 1)
+
+
+        let searchResults = searchResponse
+            .map { $0.announcements }
             .asDriver(onErrorJustReturn: [])
+
+        let totalPages = searchResponse
+            .map { $0.totalPages }
+            .asDriver(onErrorJustReturn: 0)
+
+        let hasNextPage = searchResponse
+            .map { $0.hasNext }
+            .asDriver(onErrorJustReturn: false)
+
+        let showSortBottom = input.sortTap.asDriver(onErrorJustReturn: ())
         
         let keyword = input.keyword.asDriver(onErrorJustReturn: "")
         
-        return Output(SearchResult: SearchResult, keyword: keyword)
+        return Output(
+            showSortBottom: showSortBottom,
+            searchResults: searchResults,
+            keyword: keyword,
+            totalPages: totalPages,
+            hasNextPage: hasNextPage
+        )
     }
-}
 
-extension SearchResultViewModel {
-    private func fetchJobCards(keyword: String, sortBy: String, page: Int, size: Int) -> Observable<[SearchResult]> {
-           return Observable.create { observer in
-               let request = self.searchProvider.request(
+    // MARK: - Networking
+    
+    private func fetchJobCards(keyword: String, sortBy: String, page: Int, size: Int) -> Observable<SearchResultModel> {
+        return Observable.create { observer in
+            let request = self.searchProvider.request(
                 .getSearchResult(
                     keyword: keyword,
                     sortBy: sortBy,
                     page: page,
                     size: size
                 )
-               ) { result in
-                   switch result {
-                   case .success(let response):
-                       let status = response.statusCode
-                       if 200..<300 ~= status {
-                           do {
-                               let responseDto = try response.map(BaseResponse<SearchResultModel>.self)
-                               if let data = responseDto.result?.announcements {
-                                   observer.onNext(data)
-                                   observer.onCompleted()
-                               } else {
-                                   print("no data")
-                                   observer.onError(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data available"]))
-                               }
-                           } catch {
-                               print(error.localizedDescription)
-                               observer.onError(error)
-                           }
-                       }
-                       if status >= 400 {
-                           print("400 error")
-                           observer.onError(NSError(domain: "", code: status, userInfo: [NSLocalizedDescriptionKey: "Error with status code: \(status)"]))
-                       }
-                   case .failure(let error):
-                       print(error.localizedDescription)
-                       observer.onError(error)
-                   }
-               }
+            ) { result in
+                switch result {
+                case .success(let response):
+                    let status = response.statusCode
+                    if 200..<300 ~= status {
+                        do {
+                            let responseDto = try response.map(BaseResponse<SearchResultModel>.self)
+                            if let data = responseDto.result {
+                                observer.onNext(data)
+                                observer.onCompleted()
+                            } else {
+                                print("no data")
+                                observer.onError(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data available"]))
+                            }
+                        } catch {
+                            print(error.localizedDescription)
+                            observer.onError(error)
+                        }
+                    } else if status >= 400 {
+                        print("400 error")
+                        observer.onError(NSError(domain: "", code: status, userInfo: [NSLocalizedDescriptionKey: "Error with status code: \(status)"]))
+                    }
+                case .failure(let error):
+                    print(error.localizedDescription)
+                    observer.onError(error)
+                }
+            }
 
-               return Disposables.create {
-                   request.cancel()
-               }
-           }
+            return Disposables.create {
+                request.cancel()
+            }
+        }
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
@@ -13,7 +13,7 @@ import RxCocoa
 final class SearchResultViewModel: ViewModelType {
     
     // MARK: - Properties
-
+    
     private let searchProvider = Providers.searchProvider
     
     // MARK: - Input
@@ -33,7 +33,7 @@ final class SearchResultViewModel: ViewModelType {
         let showSortBottom: Driver<Void>
         let searchResults: Driver<[SearchResult]>
         let keyword: Driver<String>
-        let totalPages: Driver<Int>
+        let totalCounts: Driver<Int>
         let hasNextPage: Driver<Bool>
     }
     
@@ -41,31 +41,26 @@ final class SearchResultViewModel: ViewModelType {
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
         let searchResponse = input.searchTrigger
-            .do(onNext: { print("searchTrigger 발생") }) 
             .withLatestFrom(Observable.combineLatest(input.keyword, input.sortBy, input.page, input.size))
             .flatMapLatest { keyword, sortBy, page, size in
-                print("Fetching job cards with keyword: \(keyword), sortBy: \(sortBy), page: \(page), size: \(size)")
-                
                 return self.fetchJobCards(keyword: keyword, sortBy: sortBy, page: page, size: size)
                     .catchAndReturn(SearchResultModel(totalPages: 0, hasNext: false, announcements: []))
             }
-            .do(onNext: { response in
-                print("Search response received: \(response)")
-            })
             .share(replay: 1)
-
+        
         let searchResults = searchResponse
             .map { $0.announcements }
             .asDriver(onErrorJustReturn: [])
-
-        let totalPages = searchResponse
+        
+        // TODO: totalPages를 totalCounts로 변경
+        let totalCounts = searchResponse
             .map { $0.totalPages }
             .asDriver(onErrorJustReturn: 0)
-
+        
         let hasNextPage = searchResponse
             .map { $0.hasNext }
             .asDriver(onErrorJustReturn: false)
-
+        
         let showSortBottom = input.sortTap.asDriver(onErrorJustReturn: ())
         
         let keyword = input.keyword.asDriver(onErrorJustReturn: "")
@@ -74,13 +69,15 @@ final class SearchResultViewModel: ViewModelType {
             showSortBottom: showSortBottom,
             searchResults: searchResults,
             keyword: keyword,
-            totalPages: totalPages,
+            totalCounts: totalCounts,
             hasNextPage: hasNextPage
         )
     }
+}
 
-    // MARK: - Networking
-    
+// MARK: - API
+
+extension SearchResultViewModel {
     private func fetchJobCards(keyword: String, sortBy: String, page: Int, size: Int) -> Observable<SearchResultModel> {
         return Observable.create { observer in
             let request = self.searchProvider.request(
@@ -101,7 +98,6 @@ final class SearchResultViewModel: ViewModelType {
                                 observer.onNext(data)
                                 observer.onCompleted()
                             } else {
-                                print("no data")
                                 observer.onError(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data available"]))
                             }
                         } catch {
@@ -109,7 +105,6 @@ final class SearchResultViewModel: ViewModelType {
                             observer.onError(error)
                         }
                     } else if status >= 400 {
-                        print("400 error")
                         observer.onError(NSError(domain: "", code: status, userInfo: [NSLocalizedDescriptionKey: "Error with status code: \(status)"]))
                     }
                 case .failure(let error):
@@ -117,7 +112,6 @@ final class SearchResultViewModel: ViewModelType {
                     observer.onError(error)
                 }
             }
-
             return Disposables.create {
                 request.cancel()
             }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
@@ -54,7 +54,6 @@ final class SearchResultViewModel: ViewModelType {
             })
             .share(replay: 1)
 
-
         let searchResults = searchResponse
             .map { $0.announcements }
             .asDriver(onErrorJustReturn: [])

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SortSetting/SortSettingViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SortSetting/SortSettingViewController.swift
@@ -29,6 +29,21 @@ enum SortingOptions: String, CaseIterable {
     var selectedColor: UIColor {
         return .terningMain
     }
+    
+    var apiValue: String {
+        switch self {
+        case .deadlineSoon:
+            return "deadlineSoon"
+        case .shortestDuration:
+            return "shortestDuration"
+        case .longestDuration:
+            return "longestDuration"
+        case .mostScrapped:
+            return "mostScrapped"
+        case .mostViewed:
+            return "mostViewed"
+        }
+    }
 }
 
 protocol SortSettingButtonProtocol: AnyObject {
@@ -133,6 +148,7 @@ class SortSettingViewController: UIViewController {
         selectedOption = option
         sortSettingDelegate?.didSelectSortingOption(option)
         
+        self.presentingViewController?.removeModalBackgroundView()
         dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #125 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
아직 탐색 결과 API가 수정되지 않아서 DTO 수정과 스크랩 수정은 하지 않았습니다!
```swift
        // TODO: totalPages를 totalCounts로 변경
        let totalCounts = searchResponse
            .map { $0.totalPages }
            .asDriver(onErrorJustReturn: 0)
```
아직 반환값에 totalCounts 가 없어서 .totalPages값을 대충 넣어둔 상태라 검색 결과가 하나로 보입니다!
추후 API 수정이 완료되면 변경하겠습니다.

변경된 UI에서는 검색 전에 그래픽보이던게 사라졌는데, 
아직 완전히 없애는 건지 확실하지 않아서 `GraphicCollectionViewCell`는 그대로 두었고, 그래픽이미지만 빈 채로 두었습니다!

검색 결과 셀도 UI가 수정되었는데 `JobCardScrapedCell`을 다른 화면에도 사용하고 있길래, 일단 수정하지 않고 두었습니다!

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

```swift
 private static func createSearchSection(hasResults: Bool) -> NSCollectionLayoutSection {
        let itemSize = NSCollectionLayoutSize(
            widthDimension: .fractionalWidth(1.0),
            heightDimension: .estimated(116)
        )
        let item = NSCollectionLayoutItem(layoutSize: itemSize)
        
        let groupSize = NSCollectionLayoutSize(
            widthDimension: .fractionalWidth(1.0),
            heightDimension: .estimated(116)
        )
        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
      
        let section = NSCollectionLayoutSection(group: group)
        section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 0, trailing: 0)
        
        if hasResults {
            let headerSize = NSCollectionLayoutSize(
                widthDimension: .fractionalWidth(1.0),
                heightDimension: .absolute(28.adjustedH)
            )
            let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
                layoutSize: headerSize,
                elementKind: UICollectionView.elementKindSectionHeader,
                alignment: .top
            )
            sectionHeader.pinToVisibleBounds = true
            section.boundarySupplementaryItems = [sectionHeader]
        } else {
            section.boundarySupplementaryItems = []
        }
        
        return section
    }
```
검색 결과가 있을때는  case .search:에 정렬 헤더 추가, 없을 때는  case .noSearch:에 정렬헤더를 추가해서 사용했습니다!



```swift
// MARK: - SortSettingButtonProtocol

extension SearchResultViewController: SortSettingButtonProtocol {
    func didSelectSortingOption(_ option: SortingOptions) {
        sortBySubject.onNext(option.apiValue)
        
        if let sortHeader = rootView.collectionView.supplementaryView(
            forElementKind: UICollectionView.elementKindSectionHeader,
            at: IndexPath(item: 0, section: 0)
        ) as? SortHeaderCell {
            sortHeader.setSortButtonTitle(option.title)
        }
    }
}
```
정렬 화면은 잘만들어주셔서 그대로 사용했습니다!

```swift
// MARK: - UIScrollViewDelegate

extension SearchResultViewController: UIScrollViewDelegate {
    func scrollViewDidScroll(_ scrollView: UIScrollView) {
        let offsetY = scrollView.contentOffset.y
        let contentHeight = scrollView.contentSize.height
        let height = scrollView.frame.size.height
        
        var isFetchingMoreData = false
        
        if offsetY >= contentHeight - height && searchHasNext && !isFetchingMoreData {
            isFetchingMoreData = true

            if let currentPage = try? pageSubject.value() {
                pageSubject.onNext(currentPage + 1)
            }
            
        }
    }
}
```
스크롤시 바닥에 도달했을때 pageSubject를 증가시키도록 구현했습니다.

```swift
        let searchTrigger = Observable.merge(searchChanged, sortChanged, pageChanged.map { _ in () })
            .withLatestFrom(Observable.combineLatest(keyword, sortBySubject)) { _, combinedValues in
                return combinedValues
            }
            .map { (keyword, _) -> String in
                return keyword
            }
            .do(onNext: { _ in
                if firstSearch {
                    firstSearch = false
                    self.rootView.searchTitleLabel.isHidden = true
                    self.rootView.updateLayout()
                    self.isFetchingMoreData = false
                }
            })
```
검색어나, 정렬이나 page가 변경될때 API를 호출 할 수 있도록 했습니다.

```swift
        output.searchResults
            .drive(onNext: { [weak self] newSearchResults in
                guard let self = self else { return }
                
                if let currentPage = try? self.pageSubject.value(), currentPage > 1 {
                    if let currentResults = self.rootView.searchResult {
                        self.rootView.searchResult = currentResults + newSearchResults
                    } else {
                        self.rootView.searchResult = newSearchResults
                    }
                } else {
                    self.rootView.collectionView.setContentOffset(.zero, animated: true)
                    self.rootView.searchResult = newSearchResults
                }
                
                self.rootView.collectionView.reloadData()
                self.isFetchingMoreData = false
            })
            .disposed(by: disposeBag)
```
page가 변경되어 searchTrigger가 발동하여 아웃풋이 나온 경우, 기존에 있던 searchResult배열에 새로 불러온 데이터들을 뒤에 추가하도록 하였습니다!

검색어나 정렬이 바뀌어 searchTrigger가 발동하여 아웃풋이 나온 경우에는, searchResult을 새롭게 바꾸고 스크롤을 콜렉션뷰의 맨위로 이동시켰습니다!

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

https://github.com/user-attachments/assets/ca07ab2d-a7b0-4a96-8187-6a64e690cfd5

-------------------------------------------------------------------------------------
### 코드 리뷰 반영 후
https://github.com/user-attachments/assets/8871dc10-81dc-4a4e-a008-43b3b761ec0c

공고 정렬 헤더 그림자 위치 수정했습니다!

<br/>
