### PR TITLE
[Fix] #149 - 공고상세페이지 QA 반영

### DIFF
--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/MainInfoTableViewCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/Cell/MainInfoTableViewCell.swift
@@ -21,18 +21,16 @@ final class MainInfoTableViewCell: UITableViewCell {
     
     private let dDayLabel = LabelFactory.build(
         text: "D-3",
-        font: .body0,
-        textColor: .terningMain,
-        lineSpacing: 1.0,
-        characterSpacing: 0.002
+        font: .title4,
+        textColor: .terningMain
     )
     
     private let titleLabel = LabelFactory.build(
         text: "[SomeOne] 콘텐츠 마케터 대학생 인턴 채용",
-        font: .title2,
+        font: .heading2,
         textAlignment: .left
     ).then {
-        $0.numberOfLines = 2
+        $0.numberOfLines = 0
     }
 
     private let viewsImage = UIImageView().then {
@@ -42,8 +40,10 @@ final class MainInfoTableViewCell: UITableViewCell {
     
     private let viewsLabel = LabelFactory.build(
         text: "3,219회",
-        font: .button4,
-        textColor: .grey400
+        font: .detail2,
+        textColor: .grey375,
+        lineSpacing: 1.2,
+        characterSpacing: 0.002
     )
     
     // MARK: - Init
@@ -79,11 +79,12 @@ extension MainInfoTableViewCell {
         dDayDivView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(20.adjustedH)
             $0.leading.equalToSuperview().inset(24.adjusted)
+            $0.width.equalTo(70.adjusted)
+            $0.height.equalTo(25.adjustedH)
         }
         
         dDayLabel.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview().inset(2.adjustedH)
-            $0.horizontalEdges.equalToSuperview().inset(20.5.adjusted)
+            $0.centerX.centerY.equalTo(dDayDivView)
         }
         
         titleLabel.snp.makeConstraints {


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #149 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
- [x] 공고 D-day 박스와 제목 간격 늘리기
- [x] 제목과 스크랩 횟수 간의 간격 늘리기
- [x] 스크랩 횟수 글씨체, 색깔 변경

간격은 피그마와 일치했는데, 글씨체와 자간, 장평이 안맞아서 간격이 좁아보였던 것 같습니다!

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

글씨체 교체한 코드 밖에 없고, 

```swift
        dDayDivView.snp.makeConstraints {
            $0.top.equalToSuperview().inset(20.adjustedH)
            $0.leading.equalToSuperview().inset(24.adjusted)
            $0.width.equalTo(70.adjusted)
            $0.height.equalTo(25.adjustedH)
        }
        
        dDayLabel.snp.makeConstraints {
            $0.centerX.centerY.equalTo(dDayDivView)
        }
```
dDay 박스의 경우, 안에 내용에 상관없이 크기 고정이라길래 레이아웃 방식만 조금 변화를 주었습니다.

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

https://github.com/user-attachments/assets/b99a5826-fd13-4092-8a96-94853ab5822b


<br/>
