### PR TITLE
[Fix] #174 -  로그인, 공고상세 스와이프, 탭바 가벼운 문제들을 해결 하였습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS/Source/Presentation/Home/HomeViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Home/HomeViewController.swift
@@ -153,6 +153,7 @@ extension HomeViewController: UICollectionViewDelegate {
             let jobDetailVC = JobDetailViewController()
             let index = jobCardLists[indexPath.row].intershipAnnouncementId
             jobDetailVC.internshipAnnouncementId.accept(index)
+            jobDetailVC.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(jobDetailVC, animated: true)
         default:
             return

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/ViewController/JobDetailViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/ViewController/JobDetailViewController.swift
@@ -39,7 +39,6 @@ final class JobDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
         
         setUI()
         setLayout()
@@ -54,6 +53,9 @@ final class JobDetailViewController: UIViewController {
 extension JobDetailViewController {
     private func setUI() {
         navigationController?.isNavigationBarHidden = true
+        navigationController?.interactivePopGestureRecognizer?.delegate = nil
+        
+        view.backgroundColor = .white
         view.addSubview(rootView)
     }
     

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -67,7 +67,7 @@ final class ProfileViewModel: ProfileViewModelType {
                 return self.signUp(
                     name: self.nameRelay.value,
                     profileImage: self.imageStringRelay.value,
-                    authType: self.userInfo?.authType ?? "KAKAO"
+                    authType: Config.authType
                 )
             }
             .asDriver(onErrorJustReturn: ())


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #174 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->

1. authType 옵셔널로 처리되어, 애플로그인도 KAKAO로 들어간 문제 해결
2. 공고 상세 스와이프로 뒤로가기 안되는 문제 해결
3. 홈뷰 `jobDetailVC.hidesBottomBarWhenPushed = true` 추가

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

1. authType 옵셔널로 처리되어, 애플로그인도 KAKAO로 들어간 문제 해결

ProfileViewModel 에서 항상 authType이 nil 이어서 , KAKAO 만 되는 문제를, authType을 직접 넣어주는 형식으로 수정하여 해결 했습니다.

```swift
authType: Config.authType
```

2. JobDetailVC 스와이프 제스처 추가

ViewDidLoad에 해당 코드를 추가해서 제스처로도 공고에서 뒤로 갈 수 있게 수정 하였습니다.

```Swift
navigationController?.interactivePopGestureRecognizer?.delegate = nil
```

3. jobDetailVC.hidesBottomBarWhenPushed = true 코드 추가해서 탭바를 없애주었습니다.

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

| 홈 -> 상세 | 캘린더 -> 상세 |
| - | - |
| ![홈](https://github.com/user-attachments/assets/4089b806-f2ae-445e-a958-2f012050660f) | ![캘린더](https://github.com/user-attachments/assets/896f523f-8ebd-43d6-a591-e94c93cd0ec8) |

<br/>

# 🖌️ Reference

[네비게이션 바 숨김 처리시 swipe 하기](https://thingjin.tistory.com/entry/iOS-%EB%82%B4%EB%B9%84%EA%B2%8C%EC%9D%B4%EC%85%98-%EB%B0%94-%EC%88%A8%EA%B9%80-%EC%8B%9C-swipe-%EC%A0%9C%EC%8A%A4%EC%B2%98%EB%A1%9C-%EB%92%A4%EB%A1%9C-%EA%B0%80%EA%B8%B0-%EA%B5%AC%ED%98%84-%ED%95%98%EA%B8%B0)

<br/>
