### PR TITLE
[Fix] #192 - 탐색뷰 스크랩 오류 수정했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -112,16 +112,16 @@ extension SearchResultViewController {
             .withLatestFrom(keyword)
             .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
             .map { _ in () }
-            .do(onNext: { _ in
-                self.pageSubject.onNext(0)
+            .do(onNext: { [weak self] _ in
+                self?.pageSubject.onNext(0)
             })
         
         let sortChanged = sortBySubject
             .withLatestFrom(keyword)
             .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
             .map { _ in () }
-            .do(onNext: { _ in
-                self.pageSubject.onNext(0)
+            .do(onNext: { [weak self] _ in
+                self?.pageSubject.onNext(0)
             })
         
         let pageChanged = pageSubject
@@ -132,7 +132,8 @@ extension SearchResultViewController {
         
         let searchTrigger = Observable.merge(searchChanged, sortChanged, pageChanged.map { _ in () })
             .withLatestFrom(keyword)
-            .do(onNext: { _ in
+            .do(onNext: { [weak self] _ in
+                guard let self = self else { return }
                 if firstSearch {
                     firstSearch = false
                     self.rootView.searchTitleLabel.isHidden = true
@@ -205,29 +206,29 @@ extension SearchResultViewController {
                 self?.searchHasNext = hasNext
             })
             .disposed(by: disposeBag)
-
+        
         output.addScrapResult
             .drive(onNext: { [weak self] in
                 guard let self = self, let index = self.selectedIndex else {
-                           return
-                       }
+                    return
+                }
                 
                 rootView.searchResult?[index].isScrapped = true
                 rootView.collectionView.reloadData()
             })
             .disposed(by: disposeBag)
-
+        
         output.cancelScrapResult
             .drive(onNext: { [weak self] in
                 guard let self = self, let index = self.selectedIndex else {
-                           return
-                       }
+                    return
+                }
                 
                 rootView.searchResult?[index].isScrapped = false
                 rootView.collectionView.reloadData()
             })
             .disposed(by: disposeBag)
-
+        
         output.error
             .drive(onNext: { [weak self] errorMessage in
                 guard let self = self else { return }
@@ -355,7 +356,7 @@ extension SearchResultViewController: UICollectionViewDelegate {
         case .search:
             guard let SearchResult = rootView.searchResult else { return }
             let selectedItem = SearchResult[indexPath.item].internshipAnnouncementId
-
+            
             let jobDetailVC = JobDetailViewController(
                 viewModel: JobDetailViewModel(
                     jobDetailRepository: JobDetailRepository(
@@ -385,7 +386,7 @@ extension SearchResultViewController: JobCardScrapedCellProtocol {
         
         let model = searchResults[index]
         selectedIndex = index
-
+        
         if model.isScrapped {
             let alertSheet = NewCustomAlertVC(alertViewType: .info)
             
@@ -394,7 +395,7 @@ extension SearchResultViewController: JobCardScrapedCellProtocol {
             
             alertSheet.centerButtonDidTapAction = { [weak self] in
                 guard let self = self else { return }
-            
+                
                 self.cancelScrapAnnouncement(scrapId: model.internshipAnnouncementId)
                 self.dismiss(animated: false)
             }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #192 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
탐색 결과에서 공고 상세로 넘어간 후, 공고 상세 페이지에서 스크랩 관련 요청을 한 후, back 버튼을 통해 탐색 결과로 돌아올 경우 해당 결과가 적용이 안되는 문제 발생
=> 해결했습니다!

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

```swift
override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(animated)
        
        if !self.isMovingToParent {
            if let currentKeyword =  rootView.searchView.textField.text,
               !currentKeyword.trimmingCharacters(in: .whitespaces).isEmpty,
               let currentPage = try? pageSubject.value() {
                sortBySubject.onNext(currentKeyword)
                pageSubject.onNext(currentPage)
            }
            
        }
    }
```
뷰 컨트롤러가 처음 부모 컨트롤러로 추가될 때, 즉 push되거나 present 될 때가 아닐때, 즉 back버튼으로 다시 화면에 돌아왔을때만
텍스트 필드값과 현재 페이지, 정렬을 그대로 전달해서 searchTrigger가 작동할 수 있도록 합니다. 

```swift
output.searchResults
            .drive(onNext: { [weak self] newSearchResults in
                guard let self = self else { return }
                self.rootView.collectionView.setContentOffset(.zero, animated: true)
                self.rootView.searchResult = newSearchResults
                self.rootView.collectionView.reloadData()
            })
            .disposed(by: disposeBag)
```
원래는 이전 페이지로 페이지 값을 줄인 후 API를 요청하는 방식을 사용을 안했어서, 이전 API 요청 값에 이후 페이지 API 요청값을 더한 배열을 화면에 띠울 수 있도록 했던 코드를 
이전 페이지, 이후 페이지 스크롤을 다 가능하게 하고, 그냥 항상 새로운 API 결과값을 화면에 뜰 수 있도록 조정하였습니다! 

```swift
rootView.collectionView.rx.prefetchItems
            .compactMap { $0.last?.item }
            .withUnretained(self)
            .bind { ss, row in
                if row == 0 {
                    if let currentPage = try? ss.pageSubject.value(), currentPage > 0 {
                        ss.pageSubject.onNext(currentPage - 1)
                    }
                } else {
                    guard ss.searchHasNext else { return }
                    if let currentPage = try? ss.pageSubject.value() {
                        ss.pageSubject.onNext(currentPage + 1)
                    }
                }
            }
            .disposed(by: disposeBag)
```
맨 위의 아이템이고, currentPage이 0보다 클때만 currentPage - 1을 수행하고, 
마지막 아이템이고, searchHasNext가 ture 일때만 currentPage + 1을 수행하도록 하였습니다. 

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

https://github.com/user-attachments/assets/4429e23c-e9fd-4c08-b39b-b44d7db5e48c



<br/>

