### PR TITLE
[Fix] #196 - 페이지 되돌아왔을때, 해당 인덱스값의 데이터만 reload되게 변경했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
@@ -127,7 +127,7 @@ final class SearchResultViewModel: ViewModelType {
 // MARK: - API
 
 extension SearchResultViewModel {
-    private func fetchJobCards(keyword: String, sortBy: String, page: Int, size: Int) -> Observable<SearchResultModel> {
+    func fetchJobCards(keyword: String, sortBy: String, page: Int, size: Int) -> Observable<SearchResultModel> {
         return Observable.create { observer in
             let request = self.searchProvider.request(
                 .getSearchResult(


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #196 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
기존처럼 아래로 스크롤될때만 페이지 증가하고, 페이지 변경 후 API 요청했을때 기존 검색결과에 새로운 검색 결과를 쌓는 형식으로 되돌려놓았습니다. 

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->
```swift
    override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(animated)
        
        if !self.isMovingToParent {
            if let indexPath = selectedIndexPath {
                reloadCollectionViewItems(at: indexPath)
            }
        }
    }
```

```swift
private func reloadCollectionViewItems(at indexPath: IndexPath) {
        let pageSize = 10
        // 요청 페이지 찾기 ex) 지금 indexPath가 18이면 28/10 = 2, 2페이지를 요청
        let pageIndex = indexPath.item / pageSize
        // 실제 받아올 인덱스 찾기 
        // ex) 지금 indexPath가 28인데, API 호출결과로는 10단위씩 전달되기 때문에 2페이지를 요청했을때 10개의 리스트중 8번째에 위치
        // 따라서 28 % 10 = 8 -> 8번째 데이터 찾기
        let itemIndexInPage = indexPath.item % pageSize
        
        // API 호출을 통해 현재 페이지 데이터 호출
        viewModel.fetchJobCards(keyword: textFieldKeyword ?? "", sortBy: sortByRelay.value, page: pageIndex, size: pageSize)
            .observe(on: MainScheduler.instance)
            .subscribe(onNext: { [weak self] result in
                guard let self = self else { return }
                
                 // API 호출결과를 announcements에 담기
                let announcements = result.announcements
                
                 // announcements가 빈배열이 아니고, itemIndexInPage가 announcements의 배열의 크기안에 있을때만 작동
                if !announcements.isEmpty && itemIndexInPage < announcements.count {
                   // 바꿀 인덱스의 announcements만 찾아서 updatedResult에 담기
                    let updatedResult = announcements[itemIndexInPage]
                    
                      // rootView의 searchResult를 currentResults에 담고, 실제 바꿀 indexPath가  currentResults의 크기보다 작은지 확인
                    if var currentResults = self.rootView.searchResult, indexPath.item < currentResults.count {
                        // updatedResult를 currentResults의 실제 바꿀 indexPath의 데이터에 넣기
                        currentResults[indexPath.item] = updatedResult
                        self.rootView.searchResult = currentResults
                       // 해당 인덱스만 리로드
                        self.rootView.collectionView.reloadItems(at: [indexPath])
                    }
                }
            })
            .disposed(by: disposeBag)
    }
```
공고 상세 페이지를 갔다가 뒤로가기로 해당 페이지에 다시 왔을때, reloadCollectionViewItems()함수가 실행되도록 하였습니다.
뷰모델의 인풋으로 요청하기에는 무조건 해당 아웃풋이 나올때 전체 결과를 수정하는 방식으로 되어있어서, 다 뜯어고쳐야하는 상황이라 지금으로썬 뷰모델의 API 호출 함수를 바로 호출해서 사용했습니다. 

reloadItems만 해주면 값에 변화가 안생겨서 공고 상세에서 스크랩 버튼을 눌렀어도, 기존 데이터가 유지되었습니다. 
따라서 공고 상세의 결과를 반영한 새로운 데이터를 받아오기 위해 API 요청을 하고 reloadItems을 해주었습니다. 

자세한 설명은 위에 코드에 주석으로 달아놓았습니다!

잘되긴하는데, 서버에서 응답을 줄때 스크랩을 하면 순서를 바꿔서 주는 경우가 몇개 있는 것 같습니다,,, 그래서 reloadItems시 화면에서 해당 셀이 사라지는 것처럼 보일때가 가끔 있습니다. 

일단 현재 배포되어있는 코드는 아예 스크롤이 안되는 오류가 있어서, 이 코드 먼저 올립니다..!
추후에 다른 해결방법을 찾아보도록 하겠습니다..

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

https://github.com/user-attachments/assets/8a6a0254-60d4-4935-a2ef-08a2f77ed347


<br/>

# 🙋🏻 질문있어요
DiffableDataSource를 쓰는 방식도 고민해 보았는데, 
DiffableDataSource도 로컬 데이터의 변화를 기반으로 UI를 업데이트 하는 역할을 해서,
공고 상세 페이지 같은 다른 외부 페이지에서 서버에 요청을 보내 변경한 데이터는 바로 반영할 수가 없었습니다..

그래서 결국 저 방식도 API를 새로 요청하고, UI를 업데이트해야하는데 
제가 지금 페이지가 추가될때마다 self.rootView.searchResult = currentResults + newSearchResults 이런 방식으로 쓰고 있으니깐,
1. 바꿀 데이터의 인덱스를 찾아서, 해당 페이지만 API를 새로 요청하거나
2. 전체 페이지를 다 요청하거나,.,. => ex) 그러면 생기는 문제가 현재가 99페이지면, 0부터 99페이지까지 다 요청해야함
둘 중 하나의 방식을 택해야 했습니다.
전체 페이지를 요청하면 적어둔것처럼 너무 많은 API를 재요청해야하는 문제가 생겼고, 
1번의 해당 페이지만 요청하는 경우
1-1) self.rootView.searchResult를 쪼개서 해당 페이지의 리스트만 찾고 그 부분만 빼서 리스트를 통채로 변경 후 다시 합친다,.,
1-2) 바꿀 데이터의 인덱스값만 지금처럼 요청한다

할 수 있는게 이렇게 두가지 방식이 나오는데 1-1은 리소스가 너무 많이 들거같고,
1-2는 지금이랑 똑같이 서버에서 응답을 줄때 스크랩을 하면 순서를 바꿔서 주는 경우를 해결하지 못하는 오류가 있습니다!.,.,.

🫠🫠🫠 어떻게 하는게 좋을까요,.,.,.,., 🥲🥲🥲
보통 어떤 방식으로 구현을 하나요,,.,...,.
