### PR TITLE
[Fix] #214 - 검색 결과 페이지 되돌아왔을때, 아이템 reload 방식 변경했습니다. 

### DIFF
--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -267,6 +267,8 @@ extension SearchResultViewController {
         let pageIndex = indexPath.item / pageSize
         let itemIndexInPage = indexPath.item % pageSize
         
+        guard let currentSearchResult = rootView.searchResult?[indexPath.item].internshipAnnouncementId else { return }
+        
         viewModel.fetchJobCards(keyword: textFieldKeyword ?? "", sortBy: sortByRelay.value, page: pageIndex, size: pageSize)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] result in
@@ -274,8 +276,7 @@ extension SearchResultViewController {
                 
                 let announcements = result.announcements
                 
-                if !announcements.isEmpty && itemIndexInPage < announcements.count {
-                    let updatedResult = announcements[itemIndexInPage]
+                if let updatedResult = announcements.first(where: { $0.internshipAnnouncementId == currentSearchResult }) {
                     
                     if var currentResults = self.rootView.searchResult, indexPath.item < currentResults.count {
                         currentResults[indexPath.item] = updatedResult
@@ -381,7 +382,7 @@ extension SearchResultViewController: UICollectionViewDelegate {
         case .search:
             guard let SearchResult = rootView.searchResult else { return }
             let selectedItem = SearchResult[indexPath.item].internshipAnnouncementId
-            
+
             selectedIndexPath = indexPath
             
             let jobDetailVC = JobDetailViewController(


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #214 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->

기존: reloadItems할때 itemIndex를 기준으로 아이템을 찾아서 데이터 변경했었음
문제: 서버에서 데이터를 주는 아이템의 순서가 바뀜
해결: reloadItems할때 internshipAnnouncementId가 같은 데이터를 넣어주는 것으로 변경

탐색 뷰 배너 때문에 한번 업데이트할 것 같아서 지금까지 생각해본 내용으로 고쳐서 올립니다!
시험만 끝나고 더 좋은 방법 찾아보겠습니다…! 낙관적 업데이트 방식도 고민해 볼 예정입니다!
일단 기능상 오류가 없게 수정하였습니다!

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->
기존 방식
```swift
private func reloadCollectionViewItems(at indexPath: IndexPath) {
        let pageSize = 10
        // 요청 페이지 찾기 ex) 지금 indexPath가 18이면 28/10 = 2, 2페이지를 요청
        let pageIndex = indexPath.item / pageSize
        // 실제 받아올 인덱스 찾기 
        // ex) 지금 indexPath가 28인데, API 호출결과로는 10단위씩 전달되기 때문에 2페이지를 요청했을때 10개의 리스트중 8번째에 위치
        // 따라서 28 % 10 = 8 -> 8번째 데이터 찾기
        let itemIndexInPage = indexPath.item % pageSize
        
        // API 호출을 통해 현재 페이지 데이터 호출
        viewModel.fetchJobCards(keyword: textFieldKeyword ?? "", sortBy: sortByRelay.value, page: pageIndex, size: pageSize)
            .observe(on: MainScheduler.instance)
            .subscribe(onNext: { [weak self] result in
                guard let self = self else { return }
                
                 // API 호출결과를 announcements에 담기
                let announcements = result.announcements
                
                 // announcements가 빈배열이 아니고, itemIndexInPage가 announcements의 배열의 크기안에 있을때만 작동
                if !announcements.isEmpty && itemIndexInPage < announcements.count {
                   // 바꿀 인덱스의 announcements만 찾아서 updatedResult에 담기
                    let updatedResult = announcements[itemIndexInPage]
                    
                      // rootView의 searchResult를 currentResults에 담고, 실제 바꿀 indexPath가  currentResults의 크기보다 작은지 확인
                    if var currentResults = self.rootView.searchResult, indexPath.item < currentResults.count {
                        // updatedResult를 currentResults의 실제 바꿀 indexPath의 데이터에 넣기
                        currentResults[indexPath.item] = updatedResult
                        self.rootView.searchResult = currentResults
                       // 해당 인덱스만 리로드
                        self.rootView.collectionView.reloadItems(at: [indexPath])
                    }
                }
            })
            .disposed(by: disposeBag)
    }
```
교체된 방식
```swift
    private func reloadCollectionViewItems(at indexPath: IndexPath) {
        let pageSize = 10
        let pageIndex = indexPath.item / pageSize
        let itemIndexInPage = indexPath.item % pageSize
        
       // currentSearchResult에 reload할 데이터의 internshipAnnouncementId 값 저장
        guard let currentSearchResult = rootView.searchResult?[indexPath.item].internshipAnnouncementId else { return }
        
        viewModel.fetchJobCards(keyword: textFieldKeyword ?? "", sortBy: sortByRelay.value, page: pageIndex, size: pageSize)
            .observe(on: MainScheduler.instance)
            .subscribe(onNext: { [weak self] result in
                guard let self = self else { return }
                
                let announcements = result.announcements
                
                // API 호출 결과 reload할 데이터의 internshipAnnouncementId과 같은 공고 id를 찾는 데이터를 updatedResult에 넣기
                if let updatedResult = announcements.first(where: { $0.internshipAnnouncementId == currentSearchResult }) {
                    
                    if var currentResults = self.rootView.searchResult, indexPath.item < currentResults.count {
                        // updatedResult를 currentResults의 실제 바꿀 indexPath의 데이터에 넣기
                        currentResults[indexPath.item] = updatedResult
                        self.rootView.searchResult = currentResults
                        // 해당 인덱스만 리로드
                        self.rootView.collectionView.reloadItems(at: [indexPath])
                    }
                }
            })
            .disposed(by: disposeBag)
    }
```

위에 변경된 내용은 주석으로 작성해 두었습니다!

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->


https://github.com/user-attachments/assets/bbdc9c71-cad1-4087-9057-213685c4e049



<br/>
