### PR TITLE
[Fix] #168 - 카카오 로그인에서 카카오 앱이 작동 안되는 문제를 해결 했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
+++ b/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
@@ -1730,6 +1730,7 @@
 		};
 		71E3C3DE2C22BAF50026C4DD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B8F503372C749309000D2A22 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1746,6 +1747,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1770,6 +1772,7 @@
 		};
 		71E3C3DF2C22BAF50026C4DD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B8F503372C749309000D2A22 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1786,6 +1789,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Terning-iOS/Terning-iOS/Info.plist
+++ b/Terning-iOS/Terning-iOS/Info.plist
@@ -2,14 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
 	<key>CFBundleDisplayName</key>
 	<string>terning</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.4</string>
 	<key>CFBundleVersion</key>
 	<string>2024.1119.2145</string>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -23,13 +25,19 @@
 	</array>
 	<key>KAKAO_NATIVE_APP_KEY</key>
 	<string>$(KAKAO_NATIVE_APP_KEY)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaotalk</string>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Light.otf</string>
@@ -54,5 +62,7 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/Terning-iOS/Terning-iOS/Resource/Utils/setImage.swift
+++ b/Terning-iOS/Terning-iOS/Resource/Utils/setImage.swift
@@ -71,7 +71,3 @@ struct RemoteImageView: View {
             .scaledToFit()
     }
 }
-
-#Preview {
-    ClosingSoonView(model: upcomingCard)
-}

--- a/Terning-iOS/Terning-iOS/Resource/Utils/setImage.swift
+++ b/Terning-iOS/Terning-iOS/Resource/Utils/setImage.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SwiftUI
 import Kingfisher
 
 public extension UIImageView {
@@ -51,4 +52,26 @@ public extension UIImageView {
             }
         )
     }
+}
+
+struct RemoteImageView: View {
+    let urlString: String
+    
+    var body: some View {
+        KFImage(URL(string: urlString))
+            .placeholder {
+                Image("img_placeholder") // 로드 중에 표시할 placeholder
+                    .resizable()
+                    .scaledToFit()
+            }
+            .resizable()
+            .fade(duration: 0.5)
+            .loadDiskFileSynchronously()
+            .cacheMemoryOnly()
+            .scaledToFit()
+    }
+}
+
+#Preview {
+    ClosingSoonView(model: upcomingCard)
 }

--- a/Terning-iOS/Terning-iOS/Source/Data/Network/Service/Providers.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Network/Service/Providers.swift
@@ -11,7 +11,7 @@ import Moya
 
 struct Providers {
     static let calendarProvider = MoyaProvider<CalendarTargetType>(withAuth: true)
-    static let authProvider = MoyaProvider<AuthTargetType>(withAuth: true)
+    static let authProvider = MoyaProvider<AuthTargetType>(withAuth: false)
     static let homeProvider = MoyaProvider<HomeTargetType>(withAuth: true)
     static let myPageProvider = MoyaProvider<MyPageTargetType>(withAuth: true)
     static let scrapsProvider = MoyaProvider<ScrapsTargetType>(withAuth: true)

--- a/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/AnnouncementsTargetType.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/AnnouncementsTargetType.swift
@@ -43,7 +43,7 @@ extension AnnouncementsTargetType: TargetType {
     }
     
     var headers: [String: String]? {
-        return Config.headerWithAccessToken
+        return Config.defaultHeader
     }
     
     var validationType: ValidationType {

--- a/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/CalendarTargetType.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/CalendarTargetType.swift
@@ -50,7 +50,7 @@ extension CalendarTargetType: TargetType {
     }
     
     var headers: [String: String]? {
-        return Config.headerWithAccessToken
+        return Config.defaultHeader
     }
     
     var validationType: ValidationType {

--- a/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/FiltersTargetType.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/FiltersTargetType.swift
@@ -56,7 +56,7 @@ extension FiltersTargetType: TargetType {
     }
     
     var headers: [String: String]? {
-        return Config.headerWithAccessToken
+        return Config.defaultHeader
     }
     
     var validationType: ValidationType {

--- a/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/HomeTargetType.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/HomeTargetType.swift
@@ -54,7 +54,7 @@ extension HomeTargetType: TargetType {
     }
     
     var headers: [String: String]? {
-        return ["Content-Type": "application/json", "Authorization": "Bearer \(Config.accessToken)"]
+        return Config.defaultHeader
     }
     
     var validationType: ValidationType {

--- a/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/MyPageTargetType.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/MyPageTargetType.swift
@@ -66,7 +66,7 @@ extension MyPageTargetType: TargetType {
     }
     
     var headers: [String: String]? {
-        return Config.headerWithAccessToken
+        return Config.defaultHeader
     }
     
     var validationType: ValidationType {

--- a/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/ScrapsTargetType.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/ScrapsTargetType.swift
@@ -53,7 +53,7 @@ extension ScrapsTargetType: TargetType {
     }
     
     var headers: [String: String]? {
-        return Config.headerWithAccessToken
+        return Config.defaultHeader
     }
     
     var validationType: ValidationType {

--- a/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/SearchTargetType.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Network/TargetType/SearchTargetType.swift
@@ -54,7 +54,7 @@ extension SearchTargetType: TargetType {
     }
     
     var headers: [String: String]? {
-        return Config.headerWithAccessToken
+        return Config.defaultHeader
     }
     
     var validationType: ValidationType {


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #168 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->

### 1. 카카오 로그인 문제를 해결 했습니다.

- info 에 `Queried URL Schemes` 추가
- xcconfig 적용되게 프로젝트에 추가 했습니다. (debug, release) -> $(KAKAO_APP_KEY) 와 같이 사용가능!


### 2. 서버 통신을 할때, TargetType 에서 헤더를 넣는게 아닌 AuthInterceptor 에서 헤더를 세팅 되게 했습니다. 
-> PR 포인트 참고
(이 부분이 이해가 안되면 디코로 알려드릴게요)

- 통신 중간에 세팅을 해서, 세션(토큰)이 만료 됐을때 retry를 해서 토큰을 세팅 해준다고 생각 해주면 될 거 같아요!

### 3. SwiftUI 에서 이미지 처리하는 Kingfisher 코드 추가

스유 브랜치에서 넣어야 하는데 모르고 커밋을 해버려서..ㅎㅎ
그냥 이런게 있다~ 정도만 보시면 될 듯 !!



<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

###  `AuthInterceptor` 서버 통신 쪽만 보면 될 것 같아요!

1) 아래  `AuthInterceptor` 함수에서

```swift
final class AuthInterceptor: RequestInterceptor { ... }
```

2) 이렇게 헤더에 세팅 되게 했숨다

```swift
urlRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
```

3) 만약에 `retry` 함수에서 에서 상태코드 401을 만나면
```swift
func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
        print("retry 진입")
        guard let response = request.task?.response as? HTTPURLResponse,
              response.statusCode == 401, // 401 뜬다면 !!
```

4) `getNewToken` 을 해서 토큰 갱신하고 다시 `adapt`를 호출해줘서 세팅 해줍니다!

```swift
UserManager.shared.getNewToken { result in // 토큰 재발급 시켜주기! -> 그 다음 adapt 실행
    switch result {
    case .success:
        print("Retry-토큰 재발급 성공")
        completion(.retry)
    case .failure(let error):
        // 세션 만료 -> 로그인 화면으로 전환
        completion(.doNotRetryWithError(error))
    }
}
```

### 결론 : 이렇게 하면 앱 사용 중간에 토큰이 만료돼도 자동으로 로그인 세션을 유지할 수 있답니다!

<br/>

# 📘 VIDEO
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

https://github.com/user-attachments/assets/fc75dc0a-03a3-4715-bbf5-0dca7bf33cb7



<br/>

# 🖌️ Reference

https://medium.com/@kyuchul2/ios-alamofire-requestinterceptor-2d7413adf450

<br/>
