### PR TITLE
[Fix] #236  - 필터링뷰 레이아웃 경고 수정

### DIFF
--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/PlanFiltering/ViewController/PlanFilteringViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/PlanFiltering/ViewController/PlanFilteringViewController.swift
@@ -85,16 +85,15 @@ extension PlanFilteringViewController {
             $0.top.horizontalEdges.equalToSuperview()
         }
         gradeButtons.snp.makeConstraints {
-            $0.top.equalTo(gradeTitleLabel.snp.bottom).offset(8.adjustedH)
+            $0.top.equalTo(gradeTitleLabel.snp.bottom).offset(12.adjustedH)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(36.adjustedH)
         }
         periodTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(gradeButtons.snp.bottom).offset(16.adjustedH)
+            $0.top.equalTo(gradeButtons.snp.bottom).offset(24.adjustedH)
             $0.leading.equalToSuperview()
         }
         periodButtons.snp.makeConstraints {
-            $0.top.equalTo(periodTitleLabel.snp.bottom).offset(8.adjustedH)
+            $0.top.equalTo(periodTitleLabel.snp.bottom).offset(12.adjustedH)
             $0.horizontalEdges.equalToSuperview()
         }
         dateTitleLabel.snp.makeConstraints {
@@ -102,7 +101,7 @@ extension PlanFilteringViewController {
             $0.leading.equalToSuperview()
         }
         customPickerView.snp.makeConstraints {
-            $0.top.equalTo(periodButtons.snp.bottom).offset(10.adjustedH)
+            $0.top.equalTo(dateTitleLabel.snp.bottom).offset(10.adjustedH)
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(170.adjustedH)
         }
@@ -123,7 +122,7 @@ extension PlanFilteringViewController {
                 originalTitle: title,
                 selectedTitle: title,
                 cornerRadius: 10,
-                height: 36
+                height: 36.adjustedH
             )
             button.tag = section * 10 + index
 


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #236 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->

- [x] UI Components 간에 간격 수정
- [x] UIStackView의 높이와 내부의 버튼 높이 충돌 해결

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->
`createButtonGroup` 함수 안에서 내부 버튼 생성시, 버튼 높이 지정 코드를 유지해 주었고, UIStackView 자체의 높이 지정을 없애주었습니다!
내부 버튼에 따라 저절로 높이가 지정되도록 해주었습니다. 
```swift
private func createButtonGroup(titles: [String], section: Int) -> UIStackView {
        let stackView = UIStackView().then {
            $0.axis = .horizontal
            $0.spacing = 12
            $0.distribution = .fillEqually
        }
        
        titles.enumerated().forEach { index, title in
            let button = CustomOnboardingButton(
                originalTitle: title,
                selectedTitle: title,
                cornerRadius: 10,
                height: 36.adjustedH
            )
            button.tag = section * 10 + index

            stackView.addArrangedSubview(button)
        }
        return stackView
    }
```
```swift
        gradeButtons.snp.makeConstraints {
            $0.top.equalTo(gradeTitleLabel.snp.bottom).offset(12.adjustedH)
            $0.horizontalEdges.equalToSuperview()
        }
```

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

https://github.com/user-attachments/assets/4d2c640b-8586-425d-afbb-922050831ced


<br/>
