### PR TITLE
[Fix] #240 - 필터링뷰 초기화 시 전달된 데이터 기반 UserFilteringData 업데이트 방식으로 수정했습니다. 

### DIFF
--- a/Terning-iOS/Terning-iOS/Source/Domain/Model/Filter/Grade.swift
+++ b/Terning-iOS/Terning-iOS/Source/Domain/Model/Filter/Grade.swift
@@ -43,3 +43,9 @@ enum Grade: String, CaseIterable, Codable {
         }
     }
 }
+
+extension Grade {
+    static func fromEnglishValue(_ value: String) -> Grade? {
+        return Grade.allCases.first { $0.englishValue == value }
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Domain/Model/Filter/JobType.swift
+++ b/Terning-iOS/Terning-iOS/Source/Domain/Model/Filter/JobType.swift
@@ -68,3 +68,9 @@ enum JobType: String, CaseIterable, Codable {
         }
     }
 }
+
+extension JobType {
+    static func fromEnglishValue(_ value: String) -> JobType? {
+        return JobType.allCases.first { $0.englishValue == value }
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Domain/Model/Filter/WorkingPeriod.swift
+++ b/Terning-iOS/Terning-iOS/Source/Domain/Model/Filter/WorkingPeriod.swift
@@ -38,3 +38,9 @@ enum WorkingPeriod: String, CaseIterable, Codable {
         }
     }
 }
+
+extension WorkingPeriod {
+    static func fromEnglishValue(_ value: String) -> WorkingPeriod? {
+        return WorkingPeriod.allCases.first { $0.englishValue == value }
+    }
+}

--- a/Terning-iOS/Terning-iOS/Source/Domain/Model/Home/UserFilteringInfoModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Domain/Model/Home/UserFilteringInfoModel.swift
@@ -11,5 +11,6 @@ struct UserFilteringInfoModel: Codable {
     let grade: String?
     let workingPeriod: String?
     let startYear: Int?
-    let startMonth: Int? 
+    let startMonth: Int?
+    let jobType: String?
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringView/ViewController/FilteringViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringView/ViewController/FilteringViewController.swift
@@ -80,8 +80,14 @@ final class FilteringViewController: UIViewController {
     
     // MARK: - Init
     
-    init(viewModel: FilteringViewModel) {
+    init(viewModel: FilteringViewModel, data: UserFilteringInfoModel) {
+        UserFilteringData.shared.grade = data.grade.flatMap { Grade(rawValue: $0) ?? Grade.fromEnglishValue($0) }
+        UserFilteringData.shared.workingPeriod = data.workingPeriod.flatMap { WorkingPeriod(rawValue: $0) ?? WorkingPeriod.fromEnglishValue($0) }
+        UserFilteringData.shared.startYear = data.startYear
+        UserFilteringData.shared.startMonth = data.startMonth
+        UserFilteringData.shared.jobType = data.jobType.flatMap { JobType(rawValue: $0) ?? JobType.fromEnglishValue($0)  }
         self.viewModel = viewModel
+        
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -97,8 +103,8 @@ final class FilteringViewController: UIViewController {
         setUI()
         setHierarchy()
         setLayout()
-        setupPageViewController()
         setupSegmentControl()
+        setupPageViewController()
         bindViewModel()
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Home/HomeViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Home/HomeViewController.swift
@@ -48,7 +48,8 @@ final class HomeViewController: UIViewController {
         grade: nil, // 기본값 설정
         workingPeriod: nil, // 기본값 설정
         startYear: nil, // 기본값 설정
-        startMonth: nil // 기본값 설정
+        startMonth: nil, // 기본값 설정
+        jobType: nil
     )
     
     private var jobCardTotalCount: JobCardModel = JobCardModel(totalCount: 0, result: [])
@@ -276,7 +277,7 @@ extension HomeViewController: FilterButtonProtocol {
                         provider: Providers.filtersProvider
                     )
                 )
-            )
+            ), data: filterInfos
         )
         
         let fraction = UISheetPresentationController.Detent.custom { _ in self.view.frame.height * ((637-32)/812) }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #240 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
FilteringViewController를 열 때, data로 필터링 정보 전달받고, 
초기화시 UserFilteringData.shared에 해당 값 업데이트해서 사용하는 방식으로 수정했습니다. 


<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

```swift
    var filterInfos: UserFilteringInfoModel = UserFilteringInfoModel(
        grade: nil, // 기본값 설정
        workingPeriod: nil, // 기본값 설정
        startYear: nil, // 기본값 설정
        startMonth: nil, // 기본값 설정
        jobType: nil
    )
```
```swift
extension HomeViewController: FilterButtonProtocol {
    func filterButtonDidTap() {
        let filterSettingVC = FilteringViewController(
            viewModel: FilteringViewModel(
                filtersRepository: FiltersRepository(
                    filtersService: FiltersService(
                        provider: Providers.filtersProvider
                    )
                )
            ), data: filterInfos
        )
```

기존의 `HomeViewController`에서 `FilteringSettingViewController`로 전달하던 data에 jobType 추가했습니다. 

```swift
    init(viewModel: FilteringViewModel, data: UserFilteringInfoModel) {
        UserFilteringData.shared.grade = data.grade.flatMap { Grade(rawValue: $0) ?? Grade.fromEnglishValue($0) }
        UserFilteringData.shared.workingPeriod = data.workingPeriod.flatMap { WorkingPeriod(rawValue: $0) ?? WorkingPeriod.fromEnglishValue($0) }
        UserFilteringData.shared.startYear = data.startYear
        UserFilteringData.shared.startMonth = data.startMonth
        UserFilteringData.shared.jobType = data.jobType.flatMap { JobType(rawValue: $0) ?? JobType.fromEnglishValue($0)  }
        self.viewModel = viewModel
        
        super.init(nibName: nil, bundle: nil)
    }
```
FilteringViewController에서  `HomeViewController`로 부터 기존과 같은 방식으로 data를 전달받고, 
init에서 Grade와 같은 필요한 enum에 값을 매핑하여 UserFilteringData에 저장하도록 하였습니다. 

PlanFilteringViewModel과 JobFilteringViewModel에서 선택되는 버튼의 초기값을 UserFilteringData의 값을 사용하도록 이미 이전 이슈에서 적용시켜두었어서, 해당 부분은 수정하지 않았습니다!



<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->
https://github.com/user-attachments/assets/c60ac428-0ade-4164-9d13-23a34e0beebc




<br/>
