### PR TITLE
[Fix] #245 - 온보딩 & 탐색뷰 3차 스프린트 QA 반영했습니다. 

### DIFF
--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomDatePicker.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomDatePicker.swift
@@ -11,7 +11,12 @@ public final class CustomDatePicker: UIPickerView {
     
     // MARK: - Properties
     
-    private(set) var years = Array(2022...2030).map { "\($0)" }
+    private(set) var years: [String] = {
+        let (currentYear, currentMonth) = Date().getCurrentKrYearAndMonth()
+        let endYear = currentMonth > 10 ? currentYear + 1 : currentYear
+        return Array(2022...endYear).map { "\($0)" }
+    }()
+
     private(set) var months = Array(1...12).map { "\($0)" }
     private var shouldRemovePlaceholderOnSelection = false
     

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/SortHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SearchResult/Cell/SortHeaderCell.swift
@@ -119,7 +119,7 @@ extension SortHeaderCell {
         
         let range = (fullText as NSString).range(of: countString)
         attributedText.addAttributes([
-            .font: UIFont.body3,
+            .font: UIFont.body5,
             .foregroundColor: UIColor.terningMain,
             .kern: 0.002,
             .paragraphStyle: paragraphStyle

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Welcome/View/WelcomeView.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Welcome/View/WelcomeView.swift
@@ -123,8 +123,9 @@ extension WelcomeView {
                 $0.height.equalTo(388.adjustedH)
             }
             skipButton.snp.makeConstraints {
+                $0.height.equalTo(14.adjustedH)
                 $0.centerX.equalToSuperview()
-                $0.bottom.equalToSuperview().inset(52.adjustedH)
+                $0.bottom.equalToSuperview().inset(44.adjustedH)
             }
         case .second:
             logoAnimationView.snp.makeConstraints {


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #245 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
**온보딩**
- [x] 시작하기 버튼과 계획 나중에 입력하기 간의 간격 수정 
- [x] 온보딩 데이트피커 연도 범위 조정 -> 매년 10월이 되었을 때 다음년도 피커가 추가되는걸로 변경
         = 필터링뷰 데이트피커 연도 범위 조정과 동일

**탐색뷰**
- [x] 총 n개의 공고가 있어요. 에서 n개에 볼드처리 안 돼있음
<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->
skipButton 바텀과 슈퍼뷰 간의 간격 수정해주었습니다. 
+ 52 -> 44로 변경
+ 버튼 높이 설정 해줌
```swift
            skipButton.snp.makeConstraints {
                $0.height.equalTo(14.adjustedH)
                $0.centerX.equalToSuperview()
                $0.bottom.equalToSuperview().inset(44.adjustedH)
            }
```

데이트 피커 초기 년도를 2022 ~ 올해, 현재 달이 10월 이상일 경우 2022 ~ 올해 + 1로 설정되도록 하였습니다. 
```swift
    private(set) var years: [String] = {
        let (currentYear, currentMonth) = Date().getCurrentKrYearAndMonth()
        let endYear = currentMonth > 10 ? currentYear + 1 : currentYear
        return Array(2022...endYear).map { "\($0)" }
    }()
```

총 n개의 공고가 있어요. 에서 n개에 볼드처리 문제는 n 폰트를 -> body3에서 body5로 변경했습니다. 
```swift
        let range = (fullText as NSString).range(of: countString)
        attributedText.addAttributes([
            .font: UIFont.body5,
            .foregroundColor: UIColor.terningMain,
            .kern: 0.002,
            .paragraphStyle: paragraphStyle
        ], range: range)
```

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

https://github.com/user-attachments/assets/3e568cfd-5590-490f-b8eb-2d1670e6858b


<img width="349" alt="스크린샷 2025-01-05 오후 11 15 41" src="https://github.com/user-attachments/assets/ca73485d-2f93-492a-99ee-c80bb6d6ceeb" />

<br/>

