### PR TITLE
[Fix] #247 - 3차 스프린트 1차 QA 반영 했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS/Resource/Amplitude/AmplitudeEventType.swift
+++ b/Terning-iOS/Terning-iOS/Resource/Amplitude/AmplitudeEventType.swift
@@ -21,8 +21,8 @@ public enum AmplitudeEventType: String {
     case clickHomeFilteringSave = "click_home_filtering_save" // 홈_필터링 재설정_저장하기
     case scrollHome = "scroll_home" // 홈_리스트 하단까지 스크롤한 횟수
     case clickFilteredDeadline = "click_filtered_deadline" // 홈_정렬_채용 마감 이른 순
-    case clickFilteredShortTerm = "click_filtered_short_term" // 홈_정렬_짧은 근무 기간 순
-    case clickFilteredLongTerm = "click_filtered_long_term" // 홈_정렬_긴 근무 기간 순
+    case clickFilteredShortTerm = "click_filtered_short_term" // 홈_정렬_근무 기간 짧은 순
+    case clickFilteredLongTerm = "click_filtered_long_term" // 홈_정렬_근무 기간 긴 순
     case clickFilteredScraps = "click_filtered_scraps" // 홈_정렬_스크랩 많은 순
     case clickFilteredHits = "click_filtered_hits" // 홈_정렬_조회수 많은 순
     case clickHomeInternCard = "click_home_intern_card" // 홈_공고 카드 클릭

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomAlertViewController.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomAlertViewController.swift
@@ -127,7 +127,7 @@ final class CustomAlertViewController: UIViewController {
         $0.spacing = 5.adjustedH
     }
     
-    private let centerButton = CustomButton(title: "내 캘린더에 스크랩 하기", font: .button3)
+    private let centerButton = CustomButton(title: "내 캘린더에 스크랩하기", font: .button3)
     private let changeColorButton = CustomButton(title: "색상 변경하기", font: .button3).setEnabled(false).setAlertViewColor()
     private let viewJobDetailButton = CustomButton(title: "공고 상세 정보 보기", font: .button3)
     private let closeButton = UIButton()
@@ -249,7 +249,7 @@ final class CustomAlertViewController: UIViewController {
         centerButton.snp.makeConstraints {
             $0.top.equalTo(detailsVStackView.snp.bottom).offset(20.adjustedH)
             $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(40)
+            $0.height.equalTo(40.adjustedH)
         }
     }
     
@@ -292,7 +292,7 @@ final class CustomAlertViewController: UIViewController {
         centerButton.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(16.adjustedH)
             $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(40)
+            $0.height.equalTo(40.adjustedH)
         }
     }
     

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomButton.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomButton.swift
@@ -73,6 +73,13 @@ extension CustomButton {
         return self
     }
     
+    @discardableResult
+    public func setCornerRadius(_ radius: CGFloat) -> Self {
+        self.layer.cornerRadius = radius
+        self.clipsToBounds = true
+        return self
+    }
+    
     /// 버튼의 backgroundColor, textColor 변경
     @discardableResult
     public func setColor(bgColor: UIColor, disableColor: UIColor, textColor: UIColor = .white) -> Self {
@@ -143,7 +150,7 @@ extension CustomButton {
             button.configuration = updatedConfiguration
             button.layer.borderColor = UIColor.grey150.cgColor
             button.layer.borderWidth = 1
-            button.layer.cornerRadius = 5
+            button.layer.cornerRadius = 8
             button.clipsToBounds = true
         }
         self.configurationUpdateHandler = buttonStateHandler

--- a/Terning-iOS/Terning-iOS/Source/Data/Network/Service/Login/LoginService.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Network/Service/Login/LoginService.swift
@@ -28,7 +28,7 @@ final class LoginService: NSObject, LoginServiceProtocol {
         return Observable<Bool>.create { observer in
             if UserApi.isKakaoTalkLoginAvailable() {
                 UserApi.shared.loginWithKakaoTalk { (oauthToken, error) in
-                    print("⭐️ kakao = \(oauthToken)")
+                    print("⭐️ kakao = \(String(describing: oauthToken))")
                     
                     if let error = error {
                         print("⭐️ kakao Error isKakaoTalkLoginAvailable = \(error.localizedDescription)")
@@ -61,7 +61,7 @@ final class LoginService: NSObject, LoginServiceProtocol {
                 }
             } else {
                 UserApi.shared.loginWithKakaoAccount { (oauthToken, error) in
-                    print("⭐️ kakao = \(oauthToken)")
+                    print("⭐️ kakao = \(String(describing: oauthToken))")
                     
                     if let error = error {
                         print("❗️ kakao Error loginWithKakaoAccount = \(error.localizedDescription)")

--- a/Terning-iOS/Terning-iOS/Source/Data/Network/User/UserManager.swift
+++ b/Terning-iOS/Terning-iOS/Source/Data/Network/User/UserManager.swift
@@ -26,6 +26,7 @@ final class UserManager {
     @UserDefaultWrapper<Int>(key: "userId") public var userId
     @UserDefaultWrapper<String>(key: "authId") public var authId
     @UserDefaultWrapper<String>(key: "authType") public var authType
+    @UserDefaultWrapper<String>(key: "userName") public var userName
     
     var hasAccessToken: Bool { return self.accessToken != nil }
     var hasKakaoToken: Bool { return self.kakaoAccessToken != nil }

--- a/Terning-iOS/Terning-iOS/Source/Domain/Model/Announcements/JobDetailModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Domain/Model/Announcements/JobDetailModel.swift
@@ -12,7 +12,7 @@ struct JobDetailModel: Codable {
     let dDay: String
     let title: String
     let workingPeriod: String
-    let isScrapped: Bool
+    var isScrapped: Bool
     let color: String?
     let deadline: String
     let startYearMonth: String

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Calendar/ViewController/TNCalendarViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Calendar/ViewController/TNCalendarViewController.swift
@@ -280,17 +280,14 @@ extension TNCalendarViewController {
         
         switch gesture.state {
         case .ended:
-            // 세로 방향의 속도가 특정 값을 넘는지 확인
-            
+            // 스와이프 속도가 500을 넘고, 주간 모드이면 월간 모드로 변경
             if velocity.y > 500 && rootView.calendarView.scope == .week {
                 rootView.calendarView.setScope(.month, animated: true)
+                
+                // #247: 선택된 날짜를 풀고, 캘린더 reloadData 하여 아래 스와이프시 초록색 터치 영역 없애주기
+                selectedDate = nil
+                self.rootView.calendarView.reloadData()
             }
-            //            } else if velocity.y > 500 {
-            //                if rootView.calendarView.scope == .week {
-            //                    rootView.calendarView.setScope(.month, animated: true)
-            //                }
-            //            }
-            // Comment: 캘린더에서 위로 스와이프하는 로직이 필요하다면 추가 작성 하기
         default:
             break
         }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/View/JobDetailView.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/View/JobDetailView.swift
@@ -56,6 +56,7 @@ final class JobDetailView: UIView {
     }
     
     private var goSiteButton = CustomButton(title: "지원 사이트로 이동하기")
+        .setCornerRadius(10)
     
     // MARK: - Init
     

--- a/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/ViewController/JobDetailViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/JobDetail/ViewController/JobDetailViewController.swift
@@ -35,6 +35,9 @@ final class JobDetailViewController: UIViewController {
     private let addScrapSubject = PublishSubject<(Int, String)>()
     private let cancelScrapSubject = PublishSubject<Int>()
     
+    // 공고 ID와 새로운 scrap 상태를 공고 외부에 전달하는 클로저
+    var didToggleScrap: ((Int, Bool) -> Void)?
+    
     // MARK: - UI Components
     
     private let rootView = JobDetailView()
@@ -113,7 +116,8 @@ extension JobDetailViewController {
 extension JobDetailViewController {
     @objc
     private func scrapButtonDidTapped(_ sender: UIButton) {
-        guard let model = self.jobDetail else { return }
+        // var를 사용해서 공고 데이터를 조작
+        guard var model = self.jobDetail else { return }
         
         if self.rootView.scrapButton.isSelected {
             let alertSheet = CustomAlertViewController(alertViewType: .info)
@@ -125,6 +129,12 @@ extension JobDetailViewController {
                 guard let self = self else { return }
                 track(eventName: .clickDetailCancelScrap)
                 self.cancelScrapAnnouncement(scrapId: self.internshipAnnouncementId.value)
+                
+                model.isScrapped.toggle()
+                rootView.setScrapped(model.isScrapped)
+                
+                didToggleScrap?(self.internshipAnnouncementId.value, model.isScrapped)
+                
                 self.dismiss(animated: false)
             }
             
@@ -141,6 +151,11 @@ extension JobDetailViewController {
                 track(eventName: .clickDetailScrap)
                 let selectedColorNameRelay = alertSheet.selectedColorNameRelay.value
                 self.addScrapAnnouncement(scrapId: self.internshipAnnouncementId.value, color: selectedColorNameRelay)
+                
+                model.isScrapped.toggle()
+                rootView.setScrapped(model.isScrapped)
+                
+                didToggleScrap?(self.internshipAnnouncementId.value, model.isScrapped)
                 self.dismiss(animated: false)
             }
             

--- a/Terning-iOS/Terning-iOS/Source/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -152,6 +152,7 @@ extension MyPageViewModel {
                             authType: data.authType
                         )
                         self.userInfoRelay.accept(updatedUserInfo)
+                        UserManager.shared.userName = data.name
                         
                         var updatedSections = self.sectionsRelay.value
                         updatedSections[0] = SectionData(

--- a/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/Cell/StickyHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/Cell/StickyHeaderCell.swift
@@ -37,7 +37,22 @@ final class StickyHeaderCell: UICollectionViewCell {
     private lazy var filterButton: UIButton = MainFilterButton()
     lazy var sortButton = MainSortButton()
     
-    private let totalCountLabel = LabelFactory.build(font: .body3)
+    private let totalLabel = LabelFactory.build(
+        text: "총",
+        font: .body3,
+        textColor: .grey400
+    )
+    
+    private let totalCountLabel = LabelFactory.build(
+        font: .body4,
+        textColor: .terningMain
+    )
+    
+    private let countLabel = LabelFactory.build(
+        text: "개",
+        font: .body3,
+        textColor: .grey400
+    )
     
     private lazy var HStackView: UIStackView = UIStackView(
         arrangedSubviews: [
@@ -71,7 +86,9 @@ extension StickyHeaderCell {
     private func setHierarchy() {
         addSubviews(
             titleLabel,
+            totalLabel,
             totalCountLabel,
+            countLabel,
             HStackView
         )
     }
@@ -82,9 +99,19 @@ extension StickyHeaderCell {
             $0.leading.equalToSuperview().offset(24.adjusted)
         }
         
-        totalCountLabel.snp.makeConstraints {
+        totalLabel.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(21.adjustedH)
             $0.leading.equalToSuperview().offset(26.adjusted)
+        }
+        
+        totalCountLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(21.adjustedH)
+            $0.leading.equalTo(totalLabel.snp.trailing).offset(4.adjusted)
+        }
+        
+        countLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(21.adjustedH)
+            $0.leading.equalTo(totalCountLabel.snp.trailing).offset(1.adjusted)
         }
         
         HStackView.snp.makeConstraints {
@@ -124,6 +151,6 @@ extension StickyHeaderCell {
             titleLabel.text = "\(name)님에게 딱 맞는 대학생 인턴 공고"
         }
         
-        totalCountLabel.text = "총 \(totalCount)개"
+        totalCountLabel.text = "\(totalCount)"
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/Cell/StickyHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/Cell/StickyHeaderCell.swift
@@ -131,7 +131,7 @@ extension StickyHeaderCell {
     
     private func setAddTarget() {
         filterButton.addTarget(self, action: #selector(filterButtonDidTap), for: .touchUpInside)
-        sortButton.addTarget(self, action: #selector(sortButtonDidTap), for: .touchUpInside)
+        sortButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(sortButtonDidTap)))
     }
     
     @objc

--- a/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/MainSortButton.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/MainSortButton.swift
@@ -7,49 +7,76 @@
 
 import UIKit
 
-final class MainSortButton: UIButton {
+import SnapKit
+import Then
+
+final class MainSortButton: UIView {
     
-    private var sortName: String
+    // MARK: - UI Components
     
-    init(sortName: String = "정렬 하기") {
-        self.sortName = sortName
-        super.init(frame: .zero)
-        
-        configureButton(sortName)
+    private let sortIconImageView = UIImageView().then {
+        $0.image = UIImage(resource: .icUnderArrow)
+    }
+    
+    private let sortNameLabel = LabelFactory.build(
+        text: "정렬하기 버튼",
+        font: .button3,
+        textColor: .grey350
+    )
+    
+    // MARK: - LifeCycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setHierarchy()
+        setLayout()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func configureButton(_ sortName: String) {
-        
-        var config = UIButton.Configuration.filled()
-        
-        config.attributedTitle = AttributedString(
-            "\(sortName)",
-            attributes: AttributeContainer([
-                .font: UIFont.button3,
-                .foregroundColor: UIColor.grey350
-            ])
+    // MARK: - UI & Layout
+    
+    private func setUI() {
+        self.isUserInteractionEnabled = true
+        self.makeBorder(width: 1, color: .grey350, cornerRadius: 5)
+    }
+    
+    private func setHierarchy() {
+        self.addSubviews(
+            sortIconImageView,
+            sortNameLabel
         )
+    }
+    
+    private func setLayout() {
+        sortIconImageView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(6.adjusted)
+        }
         
-        config.image = .icUnderArrow
-        config.imagePadding = 4.adjusted
-        
-        config.background.cornerRadius = 5
-        config.background.strokeWidth = 1
-        config.background.strokeColor = .grey350
-        config.background.backgroundColor = .white
-        
-        self.configuration = config
-        
-        self.configurationUpdateHandler = { button in
-            var updatedConfig = button.configuration
+        sortNameLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(sortIconImageView.snp.trailing).offset(3.adjusted)
+        }
+    }
+    
+    // MARK: - Methods
+    
+    func changeTitle(name: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
             
-            updatedConfig?.background.backgroundColor = (button.state == .highlighted) ? .terningPressed : .white
+            self.sortNameLabel.text = name
+            let leadingOffset = name.count < 10 ? 8.adjusted : 3.adjusted
             
-            button.configuration = updatedConfig
+            self.sortNameLabel.snp.updateConstraints {
+                $0.leading.equalTo(self.sortIconImageView.snp.trailing).offset(leadingOffset)
+            }
+            
+            self.layoutIfNeeded()
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
@@ -360,8 +360,24 @@ extension NewHomeViewController: UICollectionViewDelegate {
                     )
                 )
             )
-            let index = mainHomeDatas[indexPath.row].internshipAnnouncementId
-            jobDetailVC.internshipAnnouncementId.accept(index)
+            
+            let index = indexPath.row
+            let internshipId = mainHomeDatas[index].internshipAnnouncementId
+            
+            jobDetailVC.internshipAnnouncementId.accept(internshipId)
+            
+            /// 공고 상세에서 스크랩을 적용했을때, 스크랩 상태를 홈 공고 UI와 얼라인을 해주는 코드 입니다.
+            jobDetailVC.didToggleScrap = { [weak self] internshipId, isScrapped in
+                guard let self = self else { return }
+                
+                if let rowIndex = self.mainHomeDatas.firstIndex(where: { $0.internshipAnnouncementId == internshipId }) {
+                    self.mainHomeDatas[rowIndex].isScrapped = isScrapped
+                    
+                    let indexPath = IndexPath(row: rowIndex, section: 2)
+                    self.rootView.collectionView.reloadItems(at: [indexPath])
+                }
+            }
+            
             jobDetailVC.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(jobDetailVC, animated: true)
         default:
@@ -586,6 +602,19 @@ extension NewHomeViewController: UpcomingCardCellProtocol {
         let model = sectionTwoData[index]
         
         jobDetailViewController.internshipAnnouncementId.accept(model.internshipAnnouncementId)
+        
+        /// 공고 상세에서 스크랩을 적용했을때, 스크랩 상태를 홈 공고 UI와 얼라인을 해주는 코드 입니다.
+        jobDetailViewController.didToggleScrap = { [weak self] internshipId, isScrapped in
+            guard let self = self else { return }
+            
+            if let rowIndex = self.mainHomeDatas.firstIndex(where: { $0.internshipAnnouncementId == internshipId }) {
+                self.mainHomeDatas[rowIndex].isScrapped = isScrapped
+                
+                let indexPath = IndexPath(row: rowIndex, section: 2)
+                self.rootView.collectionView.reloadItems(at: [indexPath])
+            }
+        }
+        
         jobDetailViewController.hidesBottomBarWhenPushed = true
         
         track(eventName: .clickRemindInternCard)

--- a/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
@@ -329,7 +329,8 @@ extension NewHomeViewController: StickyHeaderCellDelegate {
                 guard let self = self else { return }
                 self.mainHomeDatas.removeAll()
                 fetchFilterInfos()
-                self.sortAndPageSubject.on(.next((apiParameter, 0)))
+                self.currentPage = 0
+                self.sortAndPageSubject.onNext((apiParameter, currentPage))
             }.disposed(by: disposeBag)
         
         track(eventName: .clickHomeFiltering)
@@ -636,11 +637,6 @@ extension NewHomeViewController {
                         guard let data = responseDto.result else { return }
                         
                         self.filterInfos = data
-                        
-                        // 0.2초 뒤에 fetchJobCardDatas 호출
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                            self.sortAndPageSubject.onNext((self.apiParameter, 0))
-                        }
                         
                     } catch {
                         print(error.localizedDescription)

--- a/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
@@ -140,6 +140,9 @@ final class NewHomeViewController: UIViewController {
         rootView.collectionView.register(JobCardCell.self, forCellWithReuseIdentifier: JobCardCell.className)
     }
     
+    
+    // MARK: - Bind
+    
     private func bindViewModel() {
         
         let input = HomeViewModel.Input(
@@ -227,11 +230,16 @@ final class NewHomeViewController: UIViewController {
             .subscribe(onNext: { [weak self] offset in
                 guard let self = self else { return }
                 
-                // 첫 번째 로직: Pagination 처리
                 self.handlePagination(offset: offset)
                 self.isLoading = false
+            })
+            .disposed(by: disposeBag)
+        
+        rootView.collectionView.rx.contentOffset
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] offset in
+                guard let self = self else { return }
                 
-                // 두 번째 로직: GradientLayerView 표시/숨김 처리
                 if offset.y > 200 {
                     self.rootView.gradientLayerView.isHidden = false
                 } else {
@@ -484,6 +492,9 @@ extension NewHomeViewController: UICollectionViewDataSource {
     }
 }
 
+
+// MARK: - SortSettingButtonProtocol
+
 extension NewHomeViewController: SortSettingButtonProtocol {
     func didSelectSortingOption(_ option: SortingOptions) {
         guard let headerView = rootView.collectionView.supplementaryView(
@@ -563,11 +574,17 @@ extension NewHomeViewController: JobCardScrapedCellProtocol {
     }
 }
 
+
+// MARK: - CheckDeadlineCellProtocol
+
 extension NewHomeViewController: CheckDeadlineCellProtocol {
     func checkDeadlineButtonDidTap() {
         self.tabBarController?.selectedIndex = 1
     }
 }
+
+
+// MARK: - UIAdaptivePresentationControllerDelegate
 
 extension NewHomeViewController: UIAdaptivePresentationControllerDelegate {
     func removeDimmedBackgroundView() {
@@ -585,6 +602,9 @@ extension NewHomeViewController: UIAdaptivePresentationControllerDelegate {
         removeDimmedBackgroundView()
     }
 }
+
+
+// MARK: - UpcomingCardCellProtocol
 
 extension NewHomeViewController: UpcomingCardCellProtocol {
     func upcomingCardDidTap(index: Int) {
@@ -623,6 +643,9 @@ extension NewHomeViewController: UpcomingCardCellProtocol {
         
     }
 }
+
+
+// MARK: - Network
 
 extension NewHomeViewController {
     private func getMyPageInfo() {

--- a/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
@@ -50,6 +50,14 @@ final class NewHomeViewController: UIViewController {
     private var totalCount: Int = 0
     private var apiParameter: String = "deadlineSoon"
     
+    private let sortDictionary: [String: SortingOptions] = [
+        "deadlineSoon": .deadlineSoon,
+        "shortestDuration": .shortestDuration,
+        "longestDuration": .longestDuration,
+        "mostScrapped": .mostScrapped,
+        "mostViewed": .mostViewed
+    ]
+    
     var filterInfos: UserFilteringInfoModel = UserFilteringInfoModel(
         grade: nil, // 기본값 설정
         workingPeriod: nil, // 기본값 설정
@@ -414,6 +422,7 @@ extension NewHomeViewController: UICollectionViewDataSource {
                 return UICollectionReusableView()
             }
             
+            headerView.sortButton.changeTitle(name: sortDictionary[apiParameter]?.rawValue ?? "")
             headerView.bind(totalCount: totalCount, name: userName)
             headerView.delegate = self
             headerView.backgroundColor = .white
@@ -517,6 +526,8 @@ extension NewHomeViewController: SortSettingButtonProtocol {
             apiParameter = "mostViewed"
             track(eventName: .clickFilteredHits)
         }
+        
+        headerView.sortButton.changeTitle(name: option.title)
         
         self.mainHomeDatas.removeAll()
         self.sortAndPageSubject.onNext((apiParameter, 0))
@@ -643,8 +654,7 @@ extension NewHomeViewController: UpcomingCardCellProtocol {
 
 extension NewHomeViewController {
     private func getMyPageInfo() {
-        myPageProvider.request(.getProfileInfo) { [weak self] result in
-            guard let self = self else { return }
+        myPageProvider.request(.getProfileInfo) { result in
             switch result {
             case .success(let response):
                 let status = response.statusCode

--- a/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
@@ -72,7 +72,7 @@ final class NewHomeViewController: UIViewController {
         }
     }
     
-    private var userName: String = "여섯글자넘음ㅋ" {
+    private lazy var userName: String = "" {
         didSet {
             rootView.updateLayout(hasScrapped: hasScrapped, soonData: sectionTwoData, userName: userName)
         }
@@ -139,7 +139,6 @@ final class NewHomeViewController: UIViewController {
         
         rootView.collectionView.register(JobCardCell.self, forCellWithReuseIdentifier: JobCardCell.className)
     }
-    
     
     // MARK: - Bind
     
@@ -492,7 +491,6 @@ extension NewHomeViewController: UICollectionViewDataSource {
     }
 }
 
-
 // MARK: - SortSettingButtonProtocol
 
 extension NewHomeViewController: SortSettingButtonProtocol {
@@ -574,7 +572,6 @@ extension NewHomeViewController: JobCardScrapedCellProtocol {
     }
 }
 
-
 // MARK: - CheckDeadlineCellProtocol
 
 extension NewHomeViewController: CheckDeadlineCellProtocol {
@@ -582,7 +579,6 @@ extension NewHomeViewController: CheckDeadlineCellProtocol {
         self.tabBarController?.selectedIndex = 1
     }
 }
-
 
 // MARK: - UIAdaptivePresentationControllerDelegate
 
@@ -602,7 +598,6 @@ extension NewHomeViewController: UIAdaptivePresentationControllerDelegate {
         removeDimmedBackgroundView()
     }
 }
-
 
 // MARK: - UpcomingCardCellProtocol
 
@@ -644,7 +639,6 @@ extension NewHomeViewController: UpcomingCardCellProtocol {
     }
 }
 
-
 // MARK: - Network
 
 extension NewHomeViewController {
@@ -660,7 +654,7 @@ extension NewHomeViewController {
                         let responseDto = try response.map(BaseResponse<UserProfileInfoModel>.self)
                         guard let data = responseDto.result else { return }
                         
-                        self.userName = data.name
+                        UserManager.shared.userName = data.name
                         
                     } catch {
                         print("사용자 정보를 불러올 수 없어요.")
@@ -689,6 +683,7 @@ extension NewHomeViewController {
                         guard let data = responseDto.result else { return }
                         
                         self.filterInfos = data
+                        self.userName = UserManager.shared.userName ?? "" // 유저 네임 viewWillAppear 시 매번 접근
                         
                     } catch {
                         print(error.localizedDescription)

--- a/Terning-iOS/Terning-iOS/Source/Presentation/SortSetting/SortSettingViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/SortSetting/SortSettingViewController.swift
@@ -13,8 +13,8 @@ import Then
 @frozen
 public enum SortingOptions: String, CaseIterable {
     case deadlineSoon = "채용 마감 이른 순" // api 명세서에 맞게 수정
-    case shortestDuration = "짧은 근무 기간 순"
-    case longestDuration = "긴 근무 기간 순"
+    case shortestDuration = "근무 기간 짧은 순"
+    case longestDuration = "근무 기간 긴 순"
     case mostScrapped = "스크랩 많은 순"
     case mostViewed = "조회수 많은 순"
     

--- a/Terning-iOS/Terning-iOS/Source/Presentation/TabBar/TNTabBarItem.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/TabBar/TNTabBarItem.swift
@@ -22,7 +22,7 @@ enum TNTabBarItem {
         case .search:
             return "탐색"
         case .myPage:
-            return "마이페이지"
+            return "마이"
         }
     }
     


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #247

<br/>

# 💙 변경된 내용
 (크리티컬한 작업 들만 적어둘게요! 간단한 문제들은 커밋 메세지 참고)
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->

### 1. 홈 화면에서 드래그 위로 올릴 때 뿌연 선보이는 문제 해결

-> 기존 rx 를 활용하여, 페이징과 스티키헤더그림자 를 동시에 구현 했었는데, throttle로 인해 스티키헤더그림자가 off되는데 지연되는 바람에 발생한 문제 였습니다.
문제를 해결하기 위해 페이징과 스티키헤더 그림자 부분을 분리 해주었습니다.

```swift
rootView.collectionView.rx.contentOffset // 페이징 코드
    .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
    .subscribe(onNext: { [weak self] offset in
        guard let self = self else { return }
        
        self.handlePagination(offset: offset)
        self.isLoading = false
    })
    .disposed(by: disposeBag)

rootView.collectionView.rx.contentOffset // 그림자 온 오프 코드 따로 분리
    .observe(on: MainScheduler.instance)
    .subscribe(onNext: { [weak self] offset in
        guard let self = self else { return }
        
        if offset.y > 200 {
            self.rootView.gradientLayerView.isHidden = false
        } else {
            self.rootView.gradientLayerView.isHidden = true
        }
    })
    .disposed(by: disposeBag)
```

이제 안남죠?

<img src = "https://github.com/user-attachments/assets/9d0977d0-bb25-4ebe-9060-dc1e2811caef" width = "40%" height = "40%">

---

### 2. 공고가 반복 되는 문제 해결
특정 이벤트들이 바뀔 때 페이지가 0으로 초기화되는 로직이 있었어야 했는데, 없어서 추가해주었습니다.
예를 들어 필터링 마친 후 페이지를 0으로 초기화하거나, 정렬을 하면 페이지가 초기화되거나!

중복되는 페이지가 없게 했어요!

<img src = "https://github.com/user-attachments/assets/6ebb49ba-bbcd-4b97-8544-c7180fed20bf" width = "40%" height = "40%">

---

### 3. 공고 상세 페이지에서 스크랩을 하고 홈 화면을 가면 스크랩이 적용이 안되는 문제를 해결

공고 상세 페이지에서 스크랩을 하고 홈 화면에서 서버를 다시 받아오는 게 아닌, 기존 클라이언트에 있는 데이터를 조작하여 스크랩 버튼을 on off 해주는 방식으로 변경했습니다.

매번 홈에서 새로고침을 해주다 보면 리소스 비효율 문제, 페이징 초기화 문제 때문에 낙관적인 업데이트 방식으로 진행했습니다.

<img src = "https://github.com/user-attachments/assets/eacbbfbe-ead7-4847-ab1c-174862733ac2" width = "40%" height = "40%">

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

한 문제를 해결할 때마다 커밋을 나누어서 개발했습니다.
사소한 문제는 커밋 메시지를 통해 변경 사항을 적어 두었습니다. !!

### CustomButton 에 round를 변경하는 함수 추가

```swift
@discardableResult
public func setCornerRadius(_ radius: CGFloat) -> Self {
    self.layer.cornerRadius = radius
    self.clipsToBounds = true
    return self
}

```

- 이제 버튼의 radius 변경 하고 싶으면 아래 처럼 쓰세용!

```swift
private var goSiteButton = CustomButton(title: "지원 사이트로 이동하기")
    .setCornerRadius(10)
```

<br/>


### 🩵 QA 목록

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/8d55bba4-1a10-4dc8-acaf-f0242ffbf801" />

<br/>

