### PR TITLE
[Fix] #249 -필터링 재설정화면 3차 스프린트 1차 QA 반영했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomSegmentedControl.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomSegmentedControl.swift
@@ -23,15 +23,21 @@ final class CustomSegmentedControl: UISegmentedControl {
     private lazy var underbar: UIView = makeUnderbar()
     private var underbarInfo: UnderbarInfo
     private var isFirstSettingDone = false
+    private var itemSpacing: CGFloat = 24
     private var underline: Bool
+    private var items: [String]
     
     // MARK: - Init
     
-    init(items: [Any]?, underbarInfo info: UnderbarInfo, underline: Bool = true) {
+    init(items: [String], underbarInfo info: UnderbarInfo, itemSpacing: CGFloat = 24, underline: Bool = true) {
+        self.items = items
         self.underbarInfo = info
+        self.itemSpacing = itemSpacing
         self.underline = underline
+        
         super.init(items: items)
         setUI()
+        setAddTarget()
     }
     
     required init?(coder: NSCoder) {
@@ -45,12 +51,33 @@ final class CustomSegmentedControl: UISegmentedControl {
         
         if !isFirstSettingDone {
             isFirstSettingDone.toggle()
+            setupItemBackgrounds()
             if underline {
                 setUnderbarMovableBackgroundLayer()
             }
             layer.masksToBounds = false
         }
+        
+        updateLabelColors()
         updateUnderbarPosition()
+    }
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        var xOffset: CGFloat = 0
+        
+        for index in 0..<numberOfSegments {
+            let textWidth = calculateTextWidth(for: index)
+            let segmentWidth = textWidth
+            let segmentFrame = CGRect(x: xOffset, y: 0, width: segmentWidth, height: bounds.height)
+            
+            if segmentFrame.contains(point) {
+                self.selectedSegmentIndex = index
+                sendActions(for: .valueChanged)
+                return self
+            }
+            xOffset += (segmentWidth + itemSpacing)
+        }
+        return nil
     }
 }
 
@@ -60,18 +87,39 @@ private extension CustomSegmentedControl {
     private func setUI() {
         removeBorders()
         let normalTextAttributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: underbarInfo.backgroundColor,
+            .foregroundColor: UIColor.clear,
             .font: UIFont.title4
         ]
-        let selectedTextAttributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: underbarInfo.highlightColor,
-            .font: UIFont.title4
-        ]
-        
         setTitleTextAttributes(normalTextAttributes, for: .normal)
-        setTitleTextAttributes(selectedTextAttributes, for: .selected)
         selectedSegmentTintColor = .clear
         selectedSegmentIndex = 0
+    }
+    
+    private func setAddTarget() {
+        addTarget(self, action: #selector(segmentValueChanged), for: .valueChanged)
+    }
+    
+    private func setupItemBackgrounds() {
+        for index in 0..<numberOfSegments {
+            let frame = frameForSegment(at: index)
+            addBackgroundView(for: frame, at: index)
+        }
+    }
+    
+    private func makeUnderbar() -> UIView {
+        let view = UIView(frame: .zero)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = underbarInfo.highlightColor
+        addSubview(view)
+        return view
+    }
+
+    private func removeBorders() {
+        let image = UIImage()
+        setBackgroundImage(image, for: .normal, barMetrics: .default)
+        setBackgroundImage(image, for: .selected, barMetrics: .default)
+        setBackgroundImage(image, for: .highlighted, barMetrics: .default)
+        setDividerImage(image, forLeftSegmentState: .normal, rightSegmentState: .normal, barMetrics: .default)
     }
     
     private func setUnderbarMovableBackgroundLayer() {
@@ -86,14 +134,6 @@ private extension CustomSegmentedControl {
         layer.addSublayer(backgroundLayer)
     }
     
-    private func makeUnderbar() -> UIView {
-        let view = UIView(frame: .zero)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = underbarInfo.highlightColor
-        addSubview(view)
-        return view
-    }
-    
     private func updateUnderbarPosition() {
         let selectedSegmentFrame = frameForSegment(at: selectedSegmentIndex)
         let textWidth = calculateTextWidth(for: selectedSegmentIndex)
@@ -102,18 +142,19 @@ private extension CustomSegmentedControl {
             self.underbar.frame = CGRect(
                 x: selectedSegmentFrame.origin.x + (selectedSegmentFrame.width - textWidth) / 2,
                 y: self.bounds.height - self.underbarInfo.height,
-                width: textWidth,
+                width: selectedSegmentFrame.width,
                 height: self.underbarInfo.height
             )
         })
     }
     
-    private func removeBorders() {
-        let image = UIImage()
-        setBackgroundImage(image, for: .normal, barMetrics: .default)
-        setBackgroundImage(image, for: .selected, barMetrics: .default)
-        setBackgroundImage(image, for: .highlighted, barMetrics: .default)
-        setDividerImage(image, forLeftSegmentState: .normal, rightSegmentState: .normal, barMetrics: .default)
+    private func updateLabelColors() {
+        for index in 0..<numberOfSegments {
+            if let backgroundView = subviews.first(where: { $0.tag == 999 + index }),
+               let label = backgroundView.subviews.first(where: { $0 is UILabel }) as? UILabel {
+                label.textColor = (selectedSegmentIndex == index) ? .terningMain : .grey300
+            }
+        }
     }
 }
 
@@ -121,15 +162,53 @@ private extension CustomSegmentedControl {
 
 extension CustomSegmentedControl {
     private func frameForSegment(at index: Int) -> CGRect {
-        let segmentWidth = bounds.width / CGFloat(numberOfSegments)
-        return CGRect(x: CGFloat(index) * segmentWidth, y: 0, width: segmentWidth, height: bounds.height)
+        let xOffset = (0..<index).reduce(0) { result, idx in
+            result + calculateTextWidth(for: idx) + itemSpacing
+        }
+        let itemWidth = calculateTextWidth(for: index)
+        return CGRect(x: xOffset, y: 0, width: itemWidth, height: bounds.height)
     }
-    
+
+    private func addBackgroundView(for frame: CGRect, at index: Int) {
+        subviews.filter { $0.tag == 999 + index }.forEach { $0.removeFromSuperview() }
+        
+        let textWidth = calculateTextWidth(for: index)
+        let segmentFrame = frameForSegment(at: index)
+        
+        let backgroundFrame = CGRect(
+            x: segmentFrame.origin.x + (segmentFrame.width - textWidth) / 2,
+            y: 0,
+            width: textWidth,
+            height: bounds.height
+        )
+        let backgroundView = UIView(frame: backgroundFrame)
+        backgroundView.tag = 999 + index
+        
+        let label = UILabel(frame: backgroundView.bounds)
+        label.text = titleForSegment(at: index)
+        label.textColor = (index == selectedSegmentIndex) ? .terningMain : .grey300
+        label.font = UIFont.title4
+        label.textAlignment = .center
+        label.tag = 1000 + index
+
+        backgroundView.addSubview(label)
+        insertSubview(backgroundView, at: 0)
+    }
+
     private func calculateTextWidth(for index: Int) -> CGFloat {
         guard let title = titleForSegment(at: index),
               let font = titleTextAttributes(for: .normal)?[.font] as? UIFont else { return 0 }
         
         let size = (title as NSString).size(withAttributes: [.font: font])
         return size.width
+    }
+}
+
+// MARK: - @objc func
+
+extension CustomSegmentedControl {
+    @objc
+    private func segmentValueChanged() {
+        updateLabelColors()
     }
 }

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomSegmentedControl.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomSegmentedControl.swift
@@ -138,13 +138,16 @@ private extension CustomSegmentedControl {
         let selectedSegmentFrame = frameForSegment(at: selectedSegmentIndex)
         let textWidth = calculateTextWidth(for: selectedSegmentIndex)
         
-        UIView.animate(withDuration: 0.27, delay: 0, options: .curveEaseOut, animations: {
+        underbar.layer.removeAllAnimations()
+        
+        UIView.animate(withDuration: 0.17, delay: 0, options: .curveLinear, animations: {
             self.underbar.frame = CGRect(
                 x: selectedSegmentFrame.origin.x + (selectedSegmentFrame.width - textWidth) / 2,
                 y: self.bounds.height - self.underbarInfo.height,
                 width: selectedSegmentFrame.width,
                 height: self.underbarInfo.height
             )
+            self.layoutIfNeeded()
         })
     }
     

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringView/ViewController/FilteringViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringView/ViewController/FilteringViewController.swift
@@ -18,8 +18,8 @@ final class UserFilteringData {
     
     var grade: Grade? 
     var workingPeriod: WorkingPeriod?
-    var startYear: Int? = Date().getCurrentKrYearAndMonth().year
-    var startMonth: Int? = Date().getCurrentKrYearAndMonth().month
+    var startYear: Int?
+    var startMonth: Int?
     var jobType: JobType?
     
     private init() {}
@@ -30,8 +30,8 @@ final class TemporaryFilteringData {
     
     var grade: Grade?
     var workingPeriod: WorkingPeriod?
-    var startYear: Int? = Date().getCurrentKrYearAndMonth().year
-    var startMonth: Int? = Date().getCurrentKrYearAndMonth().month
+    var startYear: Int?
+    var startMonth: Int?
     var jobType: JobType?
     
     private init() {}
@@ -89,8 +89,8 @@ final class FilteringViewController: UIViewController {
     init(viewModel: FilteringViewModel, data: UserFilteringInfoModel) {
         UserFilteringData.shared.grade = data.grade.flatMap { Grade(rawValue: $0) ?? Grade.fromEnglishValue($0) }
         UserFilteringData.shared.workingPeriod = data.workingPeriod.flatMap { WorkingPeriod(rawValue: $0) ?? WorkingPeriod.fromEnglishValue($0) }
-        UserFilteringData.shared.startYear = data.startYear ?? UserFilteringData.shared.startYear
-        UserFilteringData.shared.startMonth = data.startMonth ?? UserFilteringData.shared.startMonth
+        UserFilteringData.shared.startYear = (data.startYear == 0) ? nil : data.startYear
+        UserFilteringData.shared.startMonth = (data.startMonth == 0) ? nil : data.startMonth
         UserFilteringData.shared.jobType = data.jobType.flatMap { JobType(rawValue: $0) ?? JobType.fromEnglishValue($0)  }
         self.viewModel = viewModel
         

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringView/ViewController/FilteringViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringView/ViewController/FilteringViewController.swift
@@ -129,8 +129,8 @@ extension FilteringViewController {
         view.addSubviews(
             notchView,
             titleLabel,
-            segmentControl,
             underLineView,
+            segmentControl,
             saveButton
         )
     }
@@ -149,14 +149,14 @@ extension FilteringViewController {
         }
         
         segmentControl.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(20.adjustedH)
-            $0.leading.equalToSuperview().inset(20.adjusted)
-            $0.height.equalTo(40.adjustedH)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(11.adjustedH)
+            $0.leading.equalToSuperview().inset(25.adjusted)
+            $0.height.equalTo(39)
         }
         
         underLineView.snp.makeConstraints {
             $0.top.equalTo(segmentControl.snp.bottom).offset(-1)
-            $0.horizontalEdges.equalToSuperview().inset(29.adjusted)
+            $0.horizontalEdges.equalToSuperview().inset(25.adjusted)
             $0.height.equalTo(1)
         }
         

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringView/ViewController/FilteringViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/FilteringView/ViewController/FilteringViewController.swift
@@ -54,6 +54,11 @@ final class FilteringViewController: UIViewController {
         $0.isUserInteractionEnabled = true
     }
     
+    private var titleLabel = LabelFactory.build(
+        text: "필터",
+        font: .title2
+    )
+    
     private var segmentControl: CustomSegmentedControl = {
         let underbarInfo = UnderbarInfo(
             height: 4,
@@ -123,6 +128,7 @@ extension FilteringViewController {
     private func setHierarchy() {
         view.addSubviews(
             notchView,
+            titleLabel,
             segmentControl,
             underLineView,
             saveButton
@@ -137,8 +143,13 @@ extension FilteringViewController {
             $0.height.equalTo(4.adjustedH)
         }
         
-        segmentControl.snp.makeConstraints {
+        titleLabel.snp.makeConstraints {
             $0.top.equalTo(notchView.snp.bottom).offset(24.adjustedH)
+            $0.leading.equalToSuperview().inset(25.adjusted)
+        }
+        
+        segmentControl.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(20.adjustedH)
             $0.leading.equalToSuperview().inset(20.adjusted)
             $0.height.equalTo(40.adjustedH)
         }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/JobFiltering/ViewController/JobFilteringViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/JobFiltering/ViewController/JobFilteringViewController.swift
@@ -90,16 +90,10 @@ extension JobFilteringViewController {
         
         output.selectedJobType
             .drive(onNext: { [weak self] selectedJob in
-                guard let self = self else { return }
-                if let selectedJob = selectedJob,
-                   let index = JobType.allCases.firstIndex(of: selectedJob) {
-                    let indexPath = IndexPath(item: index, section: 0)
-                    self.collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .centeredVertically)
-                } else {
-                    self.collectionView.indexPathsForSelectedItems?.forEach {
-                        self.collectionView.deselectItem(at: $0, animated: false)
-                    }
-                }
+                guard let self = self, let selectedJob = selectedJob,
+                      let index = JobType.allCases.firstIndex(of: selectedJob) else { return }
+                let indexPath = IndexPath(item: index, section: 0)
+                self.collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .centeredVertically)
             })
             .disposed(by: disposeBag)
     }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/JobFiltering/ViewModel/JobFilteringViewModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/JobFiltering/ViewModel/JobFilteringViewModel.swift
@@ -15,7 +15,7 @@ final class JobFilteringViewModel: ViewModelType {
     // MARK: - Properties
     
     private let jobTypesRelay = BehaviorRelay<[JobType]>(value: JobType.allCases)
-    private let selectedJobTypeRelay = BehaviorRelay<JobType?>(value: UserFilteringData.shared.jobType)
+    private let selectedJobTypeRelay = BehaviorRelay<JobType?>(value: UserFilteringData.shared.jobType ?? JobType.allCases.last)
     
     // MARK: - Input
     
@@ -38,11 +38,7 @@ final class JobFilteringViewModel: ViewModelType {
             .subscribe(onNext: { [weak self] indexPath in
                 guard let self = self else { return }
                 let selectedJob = JobType.allCases[indexPath.item]
-                if self.selectedJobTypeRelay.value == selectedJob {
-                    self.selectedJobTypeRelay.accept(nil)
-                } else {
-                    self.selectedJobTypeRelay.accept(selectedJob)
-                }
+                self.selectedJobTypeRelay.accept(selectedJob)
             })
             .disposed(by: disposeBag)
         

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/PlanFiltering/ViewController/PlanFilteringViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/PlanFiltering/ViewController/PlanFilteringViewController.swift
@@ -20,7 +20,6 @@ final class PlanFilteringViewController: UIViewController {
     private let viewModel: PlanFilteringViewModel
     private let disposeBag = DisposeBag()
     var filteringState = BehaviorRelay<Bool>(value: false)
-    private var selectedButtons: [CustomOnboardingButton?] = [nil, nil]
    
     // MARK: - UI Components
     
@@ -135,38 +134,37 @@ extension PlanFilteringViewController {
     private func bindViewModel() {
         let gradeSelected = Observable<Grade?>.merge(
             gradeButtons.arrangedSubviews.compactMap { $0 as? CustomOnboardingButton }.map { button in
-                button.rx.tap.map { [weak self] in
-                    self?.updateSelectedButton(section: 0, sender: button)
-                    return self?.selectedButtons[0] != nil ? Grade.allCases[button.tag % 10] : nil
-                }
+                button.rx.tap.map { Grade.allCases[button.tag % 10] }
             }
         )
+        
         let periodSelected = Observable<WorkingPeriod?>.merge(
             periodButtons.arrangedSubviews.compactMap { $0 as? CustomOnboardingButton }.map { button in
-                button.rx.tap.map { [weak self] in
-                    self?.updateSelectedButton(section: 1, sender: button)
-                    return self?.selectedButtons[1] != nil ? WorkingPeriod.allCases[button.tag % 10] : nil
-                }
+                button.rx.tap.map { WorkingPeriod.allCases[button.tag % 10] }
             }
         )
+        
         let dateSelected = Observable<(Int?, Int?)>.create { [weak self] observer -> Disposable in
             self?.customPickerView.onDateSelected = { year, month in
-                self?.updateCheckBoxState()
                 observer.onNext((year, month))
             }
             return Disposables.create()
         }
         .observe(on: MainScheduler.asyncInstance)
         .share()
-
-        let checkBoxToggled: Observable<Bool> = Observable.create { [weak self] observer -> Disposable in
+        
+        let checkBoxToggled = Observable<Bool>.create { [weak self] observer -> Disposable in
             self?.checkBox.action = { isChecked in
-                self?.didTapCheckBox(isChecked: isChecked)
                 observer.onNext(isChecked)
+                if isChecked {
+                    self?.customPickerView.addPlaceholder()
+                    self?.customPickerView.removePlaceholder()
+                }
             }
             return Disposables.create()
         }
-        
+        .observe(on: MainScheduler.asyncInstance)
+
         let input = PlanFilteringViewModel.Input(
             gradeSelected: gradeSelected,
             periodSelected: periodSelected,
@@ -177,26 +175,44 @@ extension PlanFilteringViewController {
         
         let output = viewModel.transform(input: input, disposeBag: disposeBag)
         
-        output.selectedGrade
-            .drive(onNext: { [weak self] grade in
-                guard let self = self, let grade = grade else { return }
-                self.updateButtonState(for: self.gradeButtons, selectedValue: grade.displayName, section: 0)
-            })
-            .disposed(by: disposeBag)
-
-        output.selectedPeriod
-            .drive(onNext: { [weak self] period in
-                guard let self = self, let period = period else { return }
-                self.updateButtonState(for: self.periodButtons, selectedValue: period.displayName, section: 1)
-            })
-            .disposed(by: disposeBag)
-
-        Observable
-            .combineLatest(output.selectedYear.asObservable(), output.selectedMonth.asObservable())
+        Observable.combineLatest(output.selectedYear.asObservable(), output.selectedMonth.asObservable())
             .take(1)
             .subscribe(onNext: { [weak self] year, month in
-                guard let self = self, let year = year, let month = month else { return }
-                self.customPickerView.setInitialDate(year: year, month: month)
+                guard let self = self else { return }
+                
+                if let year = year, let month = month, year > 0, month > 0 {
+                    self.customPickerView.setInitialDate(year: year, month: month)
+                } else {
+                    self.customPickerView.addPlaceholder()
+                }
+            })
+            .disposed(by: disposeBag)
+
+        output.selectedGrade
+            .drive(onNext: { [weak self] grade in
+                guard let self = self else { return }
+                if let grade = grade {
+                    self.updateButtonState(for: self.gradeButtons, selectedValue: grade.displayName)
+                } else {
+                    self.updateButtonState(for: self.gradeButtons, selectedValue: nil)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        output.selectedPeriod
+            .drive(onNext: { [weak self] period in
+                guard let self = self else { return }
+                if let period = period {
+                    self.updateButtonState(for: self.periodButtons, selectedValue: period.displayName)
+                } else {
+                    self.updateButtonState(for: self.periodButtons, selectedValue: nil)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        output.isCheckBoxChecked
+            .drive(onNext: { [weak self] isChecked in
+                self?.checkBox.setChecked(isChecked)
             })
             .disposed(by: disposeBag)
         
@@ -205,59 +221,11 @@ extension PlanFilteringViewController {
             .disposed(by: disposeBag)
     }
     
-    private func updateButtonState(for buttonGroup: UIStackView, selectedValue: String?, section: Int) {
+    private func updateButtonState(for buttonGroup: UIStackView?, selectedValue: String?) {
+        guard let buttonGroup = buttonGroup else { return }
         buttonGroup.arrangedSubviews.compactMap { $0 as? CustomOnboardingButton }.forEach { button in
             let isSelected = (button.originalTitle == selectedValue)
-            if isSelected {
-                button.selectButton()
-                selectedButtons[section] = button
-            } else {
-                button.deselectButton()
-            }
-        }
-    }
-    
-    private func updateCheckBoxState() {
-        let hasSelectedButton = selectedButtons.contains { $0 != nil }
-        let pickerHasValidSelection = {
-            let selectedYearRow = customPickerView.selectedRow(inComponent: 0)
-            let selectedMonthRow = customPickerView.selectedRow(inComponent: 1)
-            
-            let yearIsValid = selectedYearRow >= 0 && selectedYearRow < customPickerView.years.count && customPickerView.years[selectedYearRow] != "-"
-            let monthIsValid = selectedMonthRow >= 0 && selectedMonthRow < customPickerView.months.count && customPickerView.months[selectedMonthRow] != "-"
-            return yearIsValid || monthIsValid
-        }()
-        if hasSelectedButton || pickerHasValidSelection {
-            checkBox.setChecked(false)
-        }
-    }
-    
-    private func updateSelectedButton(section: Int, sender: CustomOnboardingButton) {
-        if selectedButtons[section] == sender {
-            selectedButtons[section]?.deselectButton()
-            selectedButtons[section] = nil
-        } else {
-            selectedButtons[section]?.deselectButton()
-            sender.selectButton()
-            selectedButtons[section] = sender
-        }
-        updateCheckBoxState()
-    }
-}
-
-// MARK: - @objc func
-
-extension PlanFilteringViewController {
-    @objc
-    private func didTapCheckBox(isChecked: Bool) {
-        if isChecked {
-            selectedButtons.forEach { button in
-                button?.deselectButton()
-            }
-            selectedButtons = [nil, nil]
-            
-            customPickerView.addPlaceholder()
-            customPickerView.removePlaceholder()
+            isSelected ? button.selectButton() : button.deselectButton()
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/PlanFiltering/ViewController/PlanFilteringViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/PlanFiltering/ViewController/PlanFilteringViewController.swift
@@ -24,21 +24,18 @@ final class PlanFilteringViewController: UIViewController {
    
     // MARK: - UI Components
     
-    private let gradeTitleLabel = UILabel().then {
-        $0.text = "재학 상태"
-        $0.font = .systemFont(ofSize: 16, weight: .bold)
-        $0.textColor = .darkGray
-    }
-    private let periodTitleLabel = UILabel().then {
-        $0.text = "희망 근무 기간"
-        $0.font = .systemFont(ofSize: 16, weight: .bold)
-        $0.textColor = .darkGray
-    }
-    private let dateTitleLabel = UILabel().then {
-        $0.text = "근무 시작 시기"
-        $0.font = .systemFont(ofSize: 16, weight: .bold)
-        $0.textColor = .darkGray
-    }
+    private var gradeTitleLabel = LabelFactory.build(
+        text: "재학 상태",
+        font: .title4
+    )
+    private var periodTitleLabel = LabelFactory.build(
+        text: "희망 근무 기간",
+        font: .title4
+    )
+    private var dateTitleLabel = LabelFactory.build(
+        text: "근무 시작 시기",
+        font: .title4
+    )
     private lazy var gradeButtons = createButtonGroup(titles: Grade.allCases.map { $0.displayName }, section: 0)
     private lazy var periodButtons = createButtonGroup(titles: WorkingPeriod.allCases.map { $0.displayName }, section: 1)
     private var customPickerView = CustomDatePicker()
@@ -82,7 +79,7 @@ extension PlanFilteringViewController {
     }
     private func setLayout() {
         gradeTitleLabel.snp.makeConstraints {
-            $0.top.horizontalEdges.equalToSuperview()
+            $0.top.leading.equalToSuperview()
         }
         gradeButtons.snp.makeConstraints {
             $0.top.equalTo(gradeTitleLabel.snp.bottom).offset(12.adjustedH)

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/PlanFiltering/ViewModel/PlanFilteringViewModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/PlanFiltering/ViewModel/PlanFilteringViewModel.swift
@@ -91,6 +91,9 @@ final class PlanFilteringViewModel: ViewModelType {
                     self.yearRelay.accept(nil)
                     self.monthRelay.accept(nil)
                     self.hasNonNilValueRelay.accept(false)
+                    
+                    TemporaryFilteringData.shared.grade = nil
+                    TemporaryFilteringData.shared.workingPeriod = nil
                 }
             })
             .disposed(by: disposeBag)
@@ -114,6 +117,7 @@ final class PlanFilteringViewModel: ViewModelType {
                 if !isAllNil {
                     self.hasNonNilValueRelay.accept(true)
                 }
+
                 return isAllNil && !self.hasNonNilValueRelay.value
             }
             .distinctUntilChanged()

--- a/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/PlanFiltering/ViewModel/PlanFilteringViewModel.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/FilteringSetting/PlanFiltering/ViewModel/PlanFilteringViewModel.swift
@@ -13,12 +13,14 @@ final class PlanFilteringViewModel: ViewModelType {
     
     // MARK: - Properties
     
-    private let isFilterAppliedRelay = BehaviorRelay<Bool>(value: false)
+    private let hasNonNilValueRelay = BehaviorRelay<Bool>(value: false)
+    private let isCheckBoxRelay = BehaviorRelay<Bool?>(value: nil)
+    
     private let gradeRelay = BehaviorRelay<Grade?>(value: UserFilteringData.shared.grade)
     private let periodRelay = BehaviorRelay<WorkingPeriod?>(value: UserFilteringData.shared.workingPeriod)
     private let yearRelay = BehaviorRelay<Int?>(value: UserFilteringData.shared.startYear)
     private let monthRelay = BehaviorRelay<Int?>(value: UserFilteringData.shared.startMonth)
-    private let checkBoxRelay = BehaviorRelay<Bool>(value: false)
+    private let isFilterAppliedRelay = BehaviorRelay<Bool>(value: false)
     
     // MARK: - Input
     
@@ -37,6 +39,7 @@ final class PlanFilteringViewModel: ViewModelType {
         let selectedPeriod: Driver<WorkingPeriod?>
         let selectedYear: Driver<Int?>
         let selectedMonth: Driver<Int?>
+        let isCheckBoxChecked: Driver<Bool>
         let isFilterApplied: Driver<Bool>
     }
     
@@ -44,6 +47,9 @@ final class PlanFilteringViewModel: ViewModelType {
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
         input.gradeSelected
+            .withLatestFrom(gradeRelay) { (newGrade, currentGrade) in
+                return newGrade == currentGrade ? nil : newGrade
+            }
             .subscribe(onNext: { grade in
                 TemporaryFilteringData.shared.grade = grade
                 self.gradeRelay.accept(grade)
@@ -51,6 +57,9 @@ final class PlanFilteringViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.periodSelected
+            .withLatestFrom(periodRelay) { (newPeriod, currentPeriod) in
+                return newPeriod == currentPeriod ? nil : newPeriod
+            }
             .subscribe(onNext: { period in
                 TemporaryFilteringData.shared.workingPeriod = period
                 self.periodRelay.accept(period)
@@ -63,7 +72,7 @@ final class PlanFilteringViewModel: ViewModelType {
                 self.yearRelay.accept(year)
             })
             .disposed(by: disposeBag)
-
+        
         input.monthSelected
             .subscribe(onNext: { month in
                 TemporaryFilteringData.shared.startMonth = month
@@ -72,31 +81,60 @@ final class PlanFilteringViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.checkBoxToggled
-            .bind(to: checkBoxRelay)
+            .subscribe(onNext: { [weak self] isChecked in
+                guard let self = self else { return }
+                self.isCheckBoxRelay.accept(isChecked)
+
+                if isChecked {
+                    self.gradeRelay.accept(nil)
+                    self.periodRelay.accept(nil)
+                    self.yearRelay.accept(nil)
+                    self.monthRelay.accept(nil)
+                    self.hasNonNilValueRelay.accept(false)
+                }
+            })
             .disposed(by: disposeBag)
         
-        Observable
-            .combineLatest(gradeRelay, periodRelay, yearRelay, monthRelay, checkBoxRelay)
-            .do(onNext: { grade, period, year, month, isChecked in
-                    print("Grade: \(String(describing: grade))")
-                    print("Period: \(String(describing: period))")
-                    print("Year: \(String(describing: year))")
-                    print("Month: \(String(describing: month))")
-                    print("IsChecked: \(isChecked)")
-                })
-            .map { grade, period, year, month, isChecked in
-                if isChecked { return true }
+        let combinedRelays = Observable
+            .combineLatest(gradeRelay, periodRelay, yearRelay, monthRelay)
+        
+        let isCheckBoxChecked = Observable
+            .combineLatest(combinedRelays, isCheckBoxRelay.asObservable())
+            .map { [weak self] relays, isCheckBoxValue -> Bool in
+                guard let self = self else { return false }
+                let (grade, period, year, month) = relays
+                let isAllNil = grade == nil && period == nil && year == nil && month == nil
+
+                if let isCheckBoxValue = isCheckBoxValue {
+                    if !isCheckBoxValue {
+                        return false
+                    }
+                }
+
+                if !isAllNil {
+                    self.hasNonNilValueRelay.accept(true)
+                }
+                return isAllNil && !self.hasNonNilValueRelay.value
+            }
+            .distinctUntilChanged()
+            .share(replay: 1, scope: .forever)
+        
+        let isFilterApplied = Observable
+            .combineLatest(combinedRelays, isCheckBoxChecked)
+            .map { relays, isCheckBoxChecked in
+                let (grade, period, year, month) = relays
+                if isCheckBoxChecked { return true }
                 return grade != nil && period != nil && year != nil && month != nil
             }
-            .bind(to: isFilterAppliedRelay)
-            .disposed(by: disposeBag)
+            .distinctUntilChanged()
         
         return Output(
             selectedGrade: gradeRelay.asDriver(),
             selectedPeriod: periodRelay.asDriver(),
             selectedYear: yearRelay.asDriver(),
             selectedMonth: monthRelay.asDriver(),
-            isFilterApplied: isFilterAppliedRelay.asDriver()
+            isCheckBoxChecked: isCheckBoxChecked.asDriver(onErrorJustReturn: false),
+            isFilterApplied: isFilterApplied.asDriver(onErrorJustReturn: false)
         )
     }
 }

--- a/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/RefactorHome/NewHomeViewController.swift
@@ -61,8 +61,8 @@ final class NewHomeViewController: UIViewController {
     var filterInfos: UserFilteringInfoModel = UserFilteringInfoModel(
         grade: nil, // 기본값 설정
         workingPeriod: nil, // 기본값 설정
-        startYear: nil, // 기본값 설정
-        startMonth: nil, // 기본값 설정
+        startYear: 0, // 기본값 설정
+        startMonth: 0, // 기본값 설정
         jobType: nil
     )
     


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #249 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
- [x] 상단에 필터라는 텍스트가 없음
- [x] 처음 체크박스를 누른 후 데이트피커만 움직이면 저장이 활성화 되는 오류
- [x] 건너뛰기 직후 계획 필터링에 진입했을 때 체크박스가 체크되어 있지 않음
- [x] 직무 필터링 반영이 안됨
- [x] [직무 카테고리] 섹션과 [계획] 섹션 간의 간격 수정
- [x] 직무 선택 안해도 저장하기 버튼이 활성화되어 있음 -> 항상 하나는 선택되게 수정
- [x] 2가지 메뉴 슬라이드로 왔다갔다 할때, 위에 직무카테고리와 계획아래에 있는 초록색 바가 늦게 따라옴

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->
# 1️⃣번 커밋: 직무 선택 안해도 저장하기 버튼이 활성화되어 있음 -> 항상 하나는 선택되게 수정
```swift
    private let selectedJobTypeRelay = BehaviorRelay<JobType?>(value: UserFilteringData.shared.jobType ?? JobType.allCases.last)
```
저장된 직무 필터값 없을때 마지막 값인 `전체`가 뜨게했습니다. 
```swift
 func transform(input: Input, disposeBag: DisposeBag) -> Output {
        input.jobSelected
            .subscribe(onNext: { [weak self] indexPath in
                guard let self = self else { return }
                let selectedJob = JobType.allCases[indexPath.item]
                self.selectedJobTypeRelay.accept(selectedJob)
            })
            .disposed(by: disposeBag)
```
```swift
output.selectedJobType
            .drive(onNext: { [weak self] selectedJob in
                guard let self = self, let selectedJob = selectedJob,
                      let index = JobType.allCases.firstIndex(of: selectedJob) else { return }
                let indexPath = IndexPath(item: index, section: 0)
                self.collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .centeredVertically)
            })
            .disposed(by: disposeBag)
```
뷰모델과 뷰컨에서 같은 값 한번 더 누르면 값이 nil이 되는 로직을 제거했습니다.

# 2️⃣번 커밋: 상단에 필터라는 텍스트 추가
요건 그냥` 필터` 적혀있는 라벨 FilteringViewController 상단에 추가했습니다. 

# 3️⃣번 커밋: 계획필터링뷰 UILabel ->LabelFactory로 변경
PlanFilteringViewController에서 LabelFactory말고 UILabel 썼길래 수정했습니다. 

# 4️⃣번 커밋: 계획 필터링 관련 QA 반영
- 처음 체크박스를 누른 후 데이트피커만 움직이면 저장이 활성화 되는 오류 해결
- 건너뛰기 직후 계획 필터링에 진입했을 때 체크박스가 체크되어 있지 않은 오류 해결
```swift
final class UserFilteringData {
    static let shared = UserFilteringData()
    
    var grade: Grade? 
    var workingPeriod: WorkingPeriod?
    var startYear: Int?
    var startMonth: Int?
    var jobType: JobType?
    
    private init() {}
}

final class TemporaryFilteringData {
    static let shared = TemporaryFilteringData()
    
    var grade: Grade?
    var workingPeriod: WorkingPeriod?
    var startYear: Int?
    var startMonth: Int?
    var jobType: JobType?
    
    private init() {}
}
```
UserFilteringData와 TemporaryFilteringData의 `startYear, startMonth`에 현재 날짜값 넣어주는 코드 삭제했습니다. -> 초기값이 nil 이 될 수 있도록

기존의 PlanFilteringViewController에 있던 아래 코드를 삭제했습니다. 
```swift
    private var selectedButtons: [CustomOnboardingButton?] = [nil, nil]
```
선택된 버튼 값을 뷰모델만 관리하도록 옮겨주었고, 따라서 
체크 박스와 선택된 버튼값을 설정해주던 코드들을 함께 삭제했습니다. (아래 코드 삭제)
```swift
private func updateCheckBoxState() {
        let hasSelectedButton = selectedButtons.contains { $0 != nil }
        let pickerHasValidSelection = {
            let selectedYearRow = customPickerView.selectedRow(inComponent: 0)
            let selectedMonthRow = customPickerView.selectedRow(inComponent: 1)
            
            let yearIsValid = selectedYearRow >= 0 && selectedYearRow < customPickerView.years.count && customPickerView.years[selectedYearRow] != "-"
            let monthIsValid = selectedMonthRow >= 0 && selectedMonthRow < customPickerView.months.count && customPickerView.months[selectedMonthRow] != "-"
            return yearIsValid || monthIsValid
        }()
        if hasSelectedButton || pickerHasValidSelection {
            checkBox.setChecked(false)
        }
    }
    
    private func updateSelectedButton(section: Int, sender: CustomOnboardingButton) {
        if selectedButtons[section] == sender {
            selectedButtons[section]?.deselectButton()
            selectedButtons[section] = nil
        } else {
            selectedButtons[section]?.deselectButton()
            sender.selectButton()
            selectedButtons[section] = sender
        }
        updateCheckBoxState()
    }
}
```


bindViewModel() 에서 각각의 버튼이나 데이트 피커, 체크 박스가 동작할때 input으로 해당 값을 전달해주었고
```swift
 private func bindViewModel() {
        let gradeSelected = Observable<Grade?>.merge(
            gradeButtons.arrangedSubviews.compactMap { $0 as? CustomOnboardingButton }.map { button in
                button.rx.tap.map { Grade.allCases[button.tag % 10] }
            }
        )
        
        let periodSelected = Observable<WorkingPeriod?>.merge(
            periodButtons.arrangedSubviews.compactMap { $0 as? CustomOnboardingButton }.map { button in
                button.rx.tap.map { WorkingPeriod.allCases[button.tag % 10] }
            }
        )
        
        let dateSelected = Observable<(Int?, Int?)>.create { [weak self] observer -> Disposable in
            self?.customPickerView.onDateSelected = { year, month in
                observer.onNext((year, month))
            }
            return Disposables.create()
        }
        .observe(on: MainScheduler.asyncInstance)
        .share()
        
        let checkBoxToggled = Observable<Bool>.create { [weak self] observer -> Disposable in
            self?.checkBox.action = { isChecked in
                observer.onNext(isChecked)
                if isChecked {
                    self?.customPickerView.addPlaceholder()
                    self?.customPickerView.removePlaceholder()
                }
            }
            return Disposables.create()
        }
        .observe(on: MainScheduler.asyncInstance)

        let input = PlanFilteringViewModel.Input(
            gradeSelected: gradeSelected,
            periodSelected: periodSelected,
            yearSelected: dateSelected.map { $0.0 },
            monthSelected: dateSelected.map { $0.1 },
            checkBoxToggled: checkBoxToggled
        )
```
output에 따라 UI를 업데이트 해주는 함수를 호출 시켰습니다. 
년도와 요일의 경우, 뷰컨트롤러에서 '-'Placeholder를 넣어주는 작업이 필요했어서, .take(1)사용해서 초기값이 설정되는 단 한번만 초기값 년도와 달이 숫자이면 해당 숫자로 세팅 setInitialDate() 아니면 '-'가 추가되도록 하였습니다. 

이전 코드와 달리 isCheckBoxChecked와 isFilterApplied(저장하기 버튼 활성화 관련)를 분리하여 관리하였습니다.
```swift
  
        let output = viewModel.transform(input: input, disposeBag: disposeBag)
        
        Observable.combineLatest(output.selectedYear.asObservable(), output.selectedMonth.asObservable())
            .take(1)
            .subscribe(onNext: { [weak self] year, month in
                guard let self = self else { return }
                
                if let year = year, let month = month, year > 0, month > 0 {
                    self.customPickerView.setInitialDate(year: year, month: month)
                } else {
                    self.customPickerView.addPlaceholder()
                }
            })
            .disposed(by: disposeBag)

        output.selectedGrade
            .drive(onNext: { [weak self] grade in
                guard let self = self else { return }
                if let grade = grade {
                    self.updateButtonState(for: self.gradeButtons, selectedValue: grade.displayName)
                } else {
                    self.updateButtonState(for: self.gradeButtons, selectedValue: nil)
                }
            })
            .disposed(by: disposeBag)
        
        output.selectedPeriod
            .drive(onNext: { [weak self] period in
                guard let self = self else { return }
                if let period = period {
                    self.updateButtonState(for: self.periodButtons, selectedValue: period.displayName)
                } else {
                    self.updateButtonState(for: self.periodButtons, selectedValue: nil)
                }
            })
            .disposed(by: disposeBag)
        
        output.isCheckBoxChecked
            .drive(onNext: { [weak self] isChecked in
                self?.checkBox.setChecked(isChecked)
            })
            .disposed(by: disposeBag)
        
        output.isFilterApplied
            .drive(filteringState)
            .disposed(by: disposeBag)
    }
```
Output에서 isFilterApplied를 추가하여 체크 박스와 별개로 상태를 관리하였습니다. 이전 코드에서는 저장하기 상태만 관리하고, 체크 박스 상태를 뷰컨에서 관리를 하였습니다. 
Properties에서는 hasNonNilValueRelay와 isCheckBoxRelay가 추가되었습니다.(아래 설명 계속)
```swift
final class PlanFilteringViewModel: ViewModelType {
    
    // MARK: - Properties
    
    private let hasNonNilValueRelay = BehaviorRelay<Bool>(value: false)
    private let isCheckBoxRelay = BehaviorRelay<Bool?>(value: nil)
    
    private let gradeRelay = BehaviorRelay<Grade?>(value: UserFilteringData.shared.grade)
    private let periodRelay = BehaviorRelay<WorkingPeriod?>(value: UserFilteringData.shared.workingPeriod)
    private let yearRelay = BehaviorRelay<Int?>(value: UserFilteringData.shared.startYear)
    private let monthRelay = BehaviorRelay<Int?>(value: UserFilteringData.shared.startMonth)
    private let isFilterAppliedRelay = BehaviorRelay<Bool>(value: false)
    
    // MARK: - Input
    
    struct Input {
        ...
    }
    
    // MARK: - Output
    
    struct Output {
        ...
        let isCheckBoxChecked: Driver<Bool>
        let isFilterApplied: Driver<Bool>
    }
```

체크박스에 input이 들어올 경우, 체크박스가 true 인경우 나머지 계획 필터링 값을 모두 nil을 해주었고,
hasNonNilValueRelay를 false로 해주었습니다.  
```swift
 input.checkBoxToggled
            .subscribe(onNext: { [weak self] isChecked in
                guard let self = self else { return }
                self.isCheckBoxRelay.accept(isChecked)

                if isChecked {
                    self.gradeRelay.accept(nil)
                    self.periodRelay.accept(nil)
                    self.yearRelay.accept(nil)
                    self.monthRelay.accept(nil)
                    self.hasNonNilValueRelay.accept(false)
                }
            })
            .disposed(by: disposeBag)
```
hasNonNilValueRelay를 한 이유는, 
체크 박스를 클릭한 후 계획 필터링 값이 하나라도 nil이 아니게 될때 체크 박스를 false로 바꾸기 위해  아래와 같은 리턴값을 체크박스 아웃풋 값으로 반환하도록 했었는데,
```swift
  let isAllNil = grade == nil && period == nil && year == nil && month == nil
    return isAllNil 
```
이럴 경우
ex) 체크 박스를 누른 . 학년 버튼을 1학년을 눌렀다가 다시 취소한 경우 다시 체크 박스가 자동 활성화 되는 문제가 있었습니다.
```swift
  let isAllNil = grade == nil && period == nil && year == nil && month == nil
  return isAllNil && !self.hasNonNilValueRelay.value
```
따라서 위와 같은 느낌으로 hasNonNilValueRelay를 통해 사용자가 체크 박스를 누르지 않았는데 모두 Nil값이라 자동 체크박스가 체크되는 것을 방지하였습니다. 

https://github.com/user-attachments/assets/4a8c9c2a-e6b4-4366-8634-3de63100a9da



combinedRelays의 경우 체크박스 상태 결정에도 쓰이고, 저장하기 버튼 상태 결정에도 쓰여서 하나로 빼서 사용했습니다. 

isCheckBoxChecked의 경우 
1. 체크박스를 수동으로 해제한 경우 바로 우선으로 값이 false로 반환되게 함
2. 위에 설명한 것 처럼 계획 필터링 값들과, hasNonNilValueRelay를 통해 관리
```swift
let combinedRelays = Observable
            .combineLatest(gradeRelay, periodRelay, yearRelay, monthRelay)
        
        let isCheckBoxChecked = Observable
            .combineLatest(combinedRelays, isCheckBoxRelay.asObservable())
            .map { [weak self] relays, isCheckBoxValue -> Bool in
                guard let self = self else { return false }
                let (grade, period, year, month) = relays
                let isAllNil = grade == nil && period == nil && year == nil && month == nil

                if let isCheckBoxValue = isCheckBoxValue {
                    if !isCheckBoxValue {
                        return false
                    }
                }

                if !isAllNil {
                    self.hasNonNilValueRelay.accept(true)
                }
                return isAllNil && !self.hasNonNilValueRelay.value
            }
            .distinctUntilChanged()
            .share(replay: 1, scope: .forever)
        
        let isFilterApplied = Observable
            .combineLatest(combinedRelays, isCheckBoxChecked)
            .map { relays, isCheckBoxChecked in
                let (grade, period, year, month) = relays
                if isCheckBoxChecked { return true }
                return grade != nil && period != nil && year != nil && month != nil
            }
            .distinctUntilChanged()
```
isFilterApplied의 경우 isCheckBoxChecked와 combinedRelays(=계획 필터링 값들)을 통해 체크 박스가 true 상태이면 항상 저장하기 버튼 활성화, 체크 박스가 false일 경우, 모든 계획 필터링 값이 nil이 아닐때만 저장하기 버튼이 활성화 되도록 하였습니다. 

# 5️⃣번 커밋: [직무 카테고리] 섹션과 [계획] 섹션 간의 간격 수정

기본 UISegmentedControl은 기본적으로 모든 세그먼트의 너비를 균등하게 나누기 때문에,
텍스트의 위치 및 세그먼트 너비가 동일하게 고정되어 세부적인 조정이 불가능했습니다. 

텍스트 색상은 UIColor.clear로 설정해 기본 텍스트는 보이지 않게 하고 사용자 정의한 배경 뷰에 텍스트를 추가했습니다. 
보이지 않는데 아래 코드가 남아있는 이유는 CustomSegmentedControl의 크기를 기본 텍스트와 스타일 기반으로 계산하고, 이후 커스터마이징된 UI (ex 아래 추가한 backgroundView 등)에서 이를 활용하기 위해 setTitleTextAttributes를 설정했습니다.

```swift
private func setUI() {
        removeBorders()
        let normalTextAttributes: [NSAttributedString.Key: Any] = [
            .foregroundColor: UIColor.clear,
            .font: UIFont.title4
        ]
        setTitleTextAttributes(normalTextAttributes, for: .normal)
        selectedSegmentTintColor = .clear
        selectedSegmentIndex = 0
    }
```

세그먼트의 너비안에서 테스트와의 여백도 조절할 수 없었습니다. 
`setContentPositionAdjustment(_:forSegmentType:barMetrics:)`를 사용해서 억지로 조절할 순 있었으나, 
많은 시도를 해보았으나 CustomSegmentedControl로 만들기에는 조절해주는 간격을 규격화 시킬 수가 없었습니다! 
따라서 아래와 같은 방법을 사용했습니다.

frameForSegment 함수를 통해 각 세그먼트의 텍스트 크기와 간격을 기준으로 정확한 CGRect를 만들어주었습니다.
addBackgroundView를 통해 기존의 세그먼트 텍스트의 경우 기존의 세그먼트 텍스트 대신 배경 뷰와 레이블을 추가하여 텍스트를 렌더링되도록 하였습니다. 

```swift
private func frameForSegment(at index: Int) -> CGRect {
        let xOffset = (0..<index).reduce(0) { result, idx in
            result + calculateTextWidth(for: idx) + itemSpacing
        }
        let itemWidth = calculateTextWidth(for: index)
        return CGRect(x: xOffset, y: 0, width: itemWidth, height: bounds.height)
    }

    private func addBackgroundView(for frame: CGRect, at index: Int) {
        subviews.filter { $0.tag == 999 + index }.forEach { $0.removeFromSuperview() }
        
        let textWidth = calculateTextWidth(for: index)
        let segmentFrame = frameForSegment(at: index)
        
        let backgroundFrame = CGRect(
            x: segmentFrame.origin.x + (segmentFrame.width - textWidth) / 2,
            y: 0,
            width: textWidth,
            height: bounds.height
        )
        let backgroundView = UIView(frame: backgroundFrame)
        backgroundView.tag = 999 + index
        
        let label = UILabel(frame: backgroundView.bounds)
        label.text = titleForSegment(at: index)
        label.textColor = (index == selectedSegmentIndex) ? .terningMain : .grey300
        label.font = UIFont.title4
        label.textAlignment = .center
        label.tag = 1000 + index

        backgroundView.addSubview(label)
        insertSubview(backgroundView, at: 0)
    }
```

백그라운드를 추가해도, 터치 영역은 UISegmentedControl이 자동으로 계산해놓은 값 그대로 였기 때문에 터치 영역도 아래와 같이 텍스트 크기 기반으로 크기를 계산하여 설정해주었습니다. 
터치 시 selectedSegmentIndex를 즉시 업데이트하고 valueChanged 이벤트를 트리거 해줍니다.
```swift
override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
        var xOffset: CGFloat = 0
        
        for index in 0..<numberOfSegments {
            let textWidth = calculateTextWidth(for: index)
            let segmentWidth = textWidth
            let segmentFrame = CGRect(x: xOffset, y: 0, width: segmentWidth, height: bounds.height)
            
            if segmentFrame.contains(point) {
                self.selectedSegmentIndex = index
                sendActions(for: .valueChanged)
                return self
            }
            xOffset += (segmentWidth + itemSpacing)
        }
        return nil
    }
```

추가해준 백그라운드 안의 라벨들은 해당 세그먼트가 선택될때 아래 방식으로 텍스트 색깔이 바뀔 수 있도록 하였습니다. 
```swift
extension CustomSegmentedControl {
    @objc
    private func segmentValueChanged() {
        updateLabelColors()
    }
}

 private func updateLabelColors() {
        for index in 0..<numberOfSegments {
            if let backgroundView = subviews.first(where: { $0.tag == 999 + index }),
               let label = backgroundView.subviews.first(where: { $0 is UILabel }) as? UILabel {
                label.textColor = (selectedSegmentIndex == index) ? .terningMain : .grey300
            }
        }
    }
```

# 6️⃣번 커밋: 초록색 바가 따라오는 속도 수정
underbar.layer.removeAllAnimations()을 추가하여 이전에 실행중인 애니메이션이 있으면 강제로 중단하도록 하였습니다. 
애니메이션 시간을 0.27 -> 0.17로 줄였는데, 
안드가 어떻게 구현을 했는지 몰라서, 초록바 따라오는 속도가 느리다는게 애니메이션을 아예 없애라는 것일까요?? 바로 바로 밑에 뜨게? 일단 시간 줄여서 구현해놓았습니다!
```swift
private func updateUnderbarPosition() {
        let selectedSegmentFrame = frameForSegment(at: selectedSegmentIndex)
        let textWidth = calculateTextWidth(for: selectedSegmentIndex)
        
        underbar.layer.removeAllAnimations()
        
        UIView.animate(withDuration: 0.17, delay: 0, options: .curveLinear, animations: {
            self.underbar.frame = CGRect(
                x: selectedSegmentFrame.origin.x + (selectedSegmentFrame.width - textWidth) / 2,
                y: self.bounds.height - self.underbarInfo.height,
                width: selectedSegmentFrame.width,
                height: self.underbarInfo.height
            )
            self.layoutIfNeeded()
        })
    }
```


<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

https://github.com/user-attachments/assets/d168e307-0257-4104-9cea-d7dd36b6d68e


<br/>
