### PR TITLE
[Fix] #252 - 홈 화면 개수가 1000개가 넘어갈 시 문구 변경 | v1.1.1 버전 업데이트

### DIFF
--- a/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
+++ b/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
@@ -1914,7 +1914,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Terning-iOS/Terning-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2025.0119.1759;
+				CURRENT_PROJECT_VERSION = 2025.0203.2314;
 				DEVELOPMENT_TEAM = 8Q4H7X3Q58;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1931,7 +1931,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_LDFLAGS = (
 					"-Xlinker",
 					"-interposable",
@@ -1958,7 +1958,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Terning-iOS/Terning-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2025.0119.1759;
+				CURRENT_PROJECT_VERSION = 2025.0203.2314;
 				DEVELOPMENT_TEAM = 8Q4H7X3Q58;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1975,7 +1975,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.terning.Terning-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Terning-iOS/Terning-iOS/Info.plist
+++ b/Terning-iOS/Terning-iOS/Info.plist
@@ -7,9 +7,9 @@
 	<key>CFBundleDisplayName</key>
 	<string>terning</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>2025.0119.1759</string>
+	<string>2025.0203.2314</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleURLTypes</key>

--- a/Terning-iOS/Terning-iOS/Source/Presentation/Home/Cell/StickyHeaderCell.swift
+++ b/Terning-iOS/Terning-iOS/Source/Presentation/Home/Cell/StickyHeaderCell.swift
@@ -20,7 +20,7 @@ final class StickyHeaderCell: UICollectionViewCell {
     // MARK: - Properties
     
     private var count: Int = 0
-
+    
     weak var delegate: StickyHeaderCellDelegate?
     
     // MARK: - UIComponents
@@ -151,6 +151,6 @@ extension StickyHeaderCell {
             titleLabel.text = "\(name)님에게 딱 맞는 대학생 인턴 공고"
         }
         
-        totalCountLabel.text = "\(totalCount)"
+        totalCountLabel.text = totalCount >= 999 ? "999+" : "\(totalCount)"
     }
 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #252

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->

- 홈 화면에서, 공고가 1000개가 넘어 갈시 999+ 로 변경되게 수정 했어요 !
- 앱스토어 1.1.1 버전으로 업데이트 했어요 !

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

- `StickyHeaderCell`

```swift
func bind(totalCount: Int, name: String) {

   { code }
    
    totalCountLabel.text = totalCount >= 999 ? "999+" : "\(totalCount)"
}
```

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

<img src = "https://github.com/user-attachments/assets/607a4646-42eb-47a7-ad36-a63f8c00f052" width = "50%" height = "50%">

<br/>
