### PR TITLE
[Fix] #276 - 페이지 네이션 공고 중복으로 뜨는 문제 해결 했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS/Domain/Entities/Calendar/AnnouncementModel.swift
+++ b/Terning-iOS/Terning-iOS/Domain/Entities/Calendar/AnnouncementModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - AnnouncementModel
 
-struct AnnouncementModel: Codable {
+struct AnnouncementModel: Codable, Equatable {
     let internshipAnnouncementId: Int
     let companyImage: String
     let dDay: String

--- a/Terning-iOS/Terning-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Terning-iOS/Terning-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -161,6 +161,7 @@ final class HomeViewController: UIViewController {
         let output = viewModel.transform(input: input, disposeBag: disposeBag)
         
         output.jobModel
+            .distinctUntilChanged()
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] jobDatas in
                 guard let self = self else { return }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #276

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->

1. AnnouncementModel 에 Equatable confirm
2. 공고 바인딩 부분 distinctUntilChanged() 처리

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

`AnnouncementModel.swift`

```swift
struct AnnouncementModel: Codable, Equatable {

}

```

`HomeViewController.swift`

```swift
output.jobModel
    .distinctUntilChanged() // 이거 추가
    .observe(on: MainScheduler.instance)
    .subscribe(onNext: { [weak self] jobDatas in
        guard let self = self else { return }
        
        self.mainHomeDatas.append(contentsOf: jobDatas)
        
        rootView.collectionView.reloadData()
    })
    .disposed(by: disposeBag)

```

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

<img src = "https://github.com/user-attachments/assets/f6639eca-5d10-404d-b440-354bcc1d519b" width = "50%" height = "50%">


<br/>