### PR TITLE
[Feat] #288 - 강제 업데이트 구현했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
+++ b/Terning-iOS/Terning-iOS.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		2D997FBD2C9228F00078DAB0 /* beforeOnboarding.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D997FBC2C9228F00078DAB0 /* beforeOnboarding.json */; };
 		2D997FBF2C9229760078DAB0 /* afterOnboarding.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D997FBE2C9229760078DAB0 /* afterOnboarding.json */; };
 		2DAC9E7B2D112AC600A7842E /* CustomCheckButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAC9E7A2D112AC500A7842E /* CustomCheckButton.swift */; };
+		2DAFCC872DA58B0D002B9092 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 2DAFCC862DA58B0D002B9092 /* FirebaseRemoteConfig */; };
 		2DC61EF32C4075E3009F991F /* JobDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EF22C4075E3009F991F /* JobDetailViewController.swift */; };
 		2DC61EF52C4075EB009F991F /* MainInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EF42C4075EB009F991F /* MainInfoTableViewCell.swift */; };
 		2DC61EF72C4075F3009F991F /* JobDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC61EF62C4075F3009F991F /* JobDetailViewModel.swift */; };
@@ -450,6 +451,7 @@
 				71E3C4062C241DD40026C4DD /* ReactiveMoya in Frameworks */,
 				2DC61F2C2C4213C7009F991F /* KakaoSDK in Frameworks */,
 				2DC61F2E2C4213C7009F991F /* KakaoSDKAuth in Frameworks */,
+				2DAFCC872DA58B0D002B9092 /* FirebaseRemoteConfig in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -699,6 +701,13 @@
 				2DD419C92CA46D2900F647DC /* loginAnimation.json */,
 			);
 			path = Lotties;
+			sourceTree = "<group>";
+		};
+		2DAFCC852DA58B0D002B9092 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		2DC61EEE2C40759F009F991F /* JobDetail */ = {
@@ -1224,6 +1233,7 @@
 			children = (
 				71E3C40C2C2423280026C4DD /* .swiftlint.yml */,
 				71E3C3CB2C22BAF40026C4DD /* Terning-iOS */,
+				2DAFCC852DA58B0D002B9092 /* Frameworks */,
 				71E3C3CA2C22BAF40026C4DD /* Products */,
 			);
 			sourceTree = "<group>";
@@ -1494,6 +1504,7 @@
 				719D09152D74CC6200899C22 /* FirebaseCore */,
 				719D09192D74DE7100899C22 /* FirebaseAuth */,
 				719D091B2D74DE7100899C22 /* FirebaseMessaging */,
+				2DAFCC862DA58B0D002B9092 /* FirebaseRemoteConfig */,
 			);
 			productName = "Terning-iOS";
 			productReference = 71E3C3C92C22BAF40026C4DD /* Terning-iOS.app */;
@@ -2102,6 +2113,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2D997FAC2C91A6460078DAB0 /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
+		};
+		2DAFCC862DA58B0D002B9092 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 719D09122D74CC6200899C22 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
 		};
 		2DC61F2B2C4213C7009F991F /* KakaoSDK */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Terning-iOS/Terning-iOS/Presentation/Splash/SplashViewController.swift
+++ b/Terning-iOS/Terning-iOS/Presentation/Splash/SplashViewController.swift
@@ -125,14 +125,13 @@ extension SplashVC {
                 return
             }
             
-            let remoteVersion = remoteConfig.configValue(forKey: "android_app_version").stringValue
-//            let remoteVersion = "1.1.6"
-            let majorTitle = remoteConfig.configValue(forKey: "android_major_update_title").stringValue
-            let majorBody = remoteConfig.configValue(forKey: "android_major_update_body").stringValue
-            let patchTitle = remoteConfig.configValue(forKey: "android_patch_update_title").stringValue
-            let patchBody = remoteConfig.configValue(forKey: "android_patch_update_body").stringValue
+            let remoteVersion = remoteConfig.configValue(forKey: "ios_app_version").stringValue
+            let majorTitle = remoteConfig.configValue(forKey: "ios_major_update_title").stringValue
+            let majorBody = remoteConfig.configValue(forKey: "ios_major_update_body").stringValue
+            let patchTitle = remoteConfig.configValue(forKey: "ios_patch_update_title").stringValue
+            let patchBody = remoteConfig.configValue(forKey: "ios_patch_update_body").stringValue
             let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-
+            
             guard !remoteVersion.isEmpty else {
                 print("🌷❌ Remote Config에서 앱 버전이 누락됨")
                 return

--- a/Terning-iOS/Terning-iOS/Presentation/Splash/SplashViewController.swift
+++ b/Terning-iOS/Terning-iOS/Presentation/Splash/SplashViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import FirebaseRemoteConfig
+
 import SnapKit
 import Then
 
@@ -27,7 +29,27 @@ final class SplashVC: UIViewController {
         self.setUI()
         self.setNavigationBar()
         self.setLayout()
-        self.checkDidSignIn()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        self.checkAppVersion {
+            self.checkDidSignIn()
+        }
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 }
 
@@ -70,6 +92,134 @@ extension SplashVC {
         let tabBarController = TNTabBarController()
         guard let window = self.view.window else { return }
         ViewControllerUtils.setRootViewController(window: window, viewController: tabBarController, withAnimation: true)
+    }
+}
+
+// MARK: - Update Methods
+
+extension SplashVC {
+    func checkAppVersion(completion: @escaping () -> Void) {
+        let remoteConfig = RemoteConfig.remoteConfig()
+        let settings = RemoteConfigSettings()
+        settings.minimumFetchInterval = 86400
+        remoteConfig.configSettings = settings
+
+        remoteConfig.fetchAndActivate { status, error in
+            if let error = error {
+                print("🌷❌ Remote Config fetch error: \(error.localizedDescription)")
+                completion()
+                return
+            }
+
+            switch status {
+            case .successFetchedFromRemote:
+                print("🌷✅ Remote Config: fetched from remote")
+            case .successUsingPreFetchedData:
+                print("🌷ℹ️ Remote Config: using cached data")
+            case .error:
+                completion()
+                print("🌷⚠️ Remote Config: activation error")
+                return
+            @unknown default:
+                completion()
+                print("🌷⚠️ Remote Config: unknown status")
+                return
+            }
+
+            let remoteVersion = remoteConfig.configValue(forKey: "android_app_version").stringValue
+//            let remoteVersion = "1.1.6"
+            let majorTitle = remoteConfig.configValue(forKey: "android_major_update_title").stringValue
+            let majorBody = remoteConfig.configValue(forKey: "android_major_update_body").stringValue
+            let patchTitle = remoteConfig.configValue(forKey: "android_patch_update_title").stringValue
+            let patchBody = remoteConfig.configValue(forKey: "android_patch_update_body").stringValue
+            let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+
+            guard !remoteVersion.isEmpty else {
+                print("🌷❌ Remote Config에서 앱 버전이 누락됨")
+                return
+            }
+
+            guard currentVersion?.compare(remoteVersion, options: .numeric) == .orderedAscending else {
+                print("🌷✅ 최신 버전입니다")
+                completion()
+                return
+            }
+
+            let currentComponents = currentVersion?.split(separator: ".").compactMap { Int($0) } ?? [0, 0, 0]
+            let remoteComponents = remoteVersion.split(separator: ".").compactMap { Int($0) }
+
+            let currentMajor = currentComponents[0]
+            let currentMinor = currentComponents[1]
+
+            let remoteMajor = remoteComponents[0]
+            let remoteMinor = remoteComponents[1]
+
+            let isMajorUpdate = remoteMajor > currentMajor || (remoteMajor == currentMajor && remoteMinor > currentMinor)
+
+            let type: UpdateAlertViewController.UpdateViewType = isMajorUpdate ? .force : .normal
+            let titleRaw = isMajorUpdate ? majorTitle : patchTitle
+            let bodyRaw = isMajorUpdate ? majorBody : patchBody
+            
+            let title = titleRaw.replacingOccurrences(of: "\\n", with: "\n")
+            let body = bodyRaw.replacingOccurrences(of: "\\n", with: "\n")
+
+            guard !title.isEmpty, !body.isEmpty else {
+                print("🌷❌ 업데이트 문구 누락 → 팝업 표시 중단")
+                completion()
+                return
+            }
+
+            let updateVC = UpdateAlertViewController(updateViewType: type, title: title, discription: body)
+            updateVC.modalPresentationStyle = .overFullScreen
+
+            if let windowScene = UIApplication.shared.connectedScenes
+                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+               let rootVC = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController {
+                rootVC.present(updateVC, animated: false)
+            }
+
+            updateVC.rx.centerButtonTap
+                .bind { [weak updateVC] in
+                    UserDefaults.standard.set(true, forKey: "isWaitingForForceUpdate")
+                    self.goToAppStore()
+                    updateVC?.dismiss(animated: true)
+                }
+                .disposed(by: updateVC.disposeBag)
+
+            updateVC.rx.rightButtonTap
+                .bind { [weak updateVC] in
+                    UserDefaults.standard.set(true, forKey: "isWaitingForForceUpdate")
+                    self.goToAppStore()
+                    updateVC?.dismiss(animated: true)
+                }
+                .disposed(by: updateVC.disposeBag)
+
+            updateVC.rx.leftButtonTap
+                .bind { [weak updateVC] in
+                    updateVC?.dismiss(animated: true)
+                    completion()
+                }
+                .disposed(by: updateVC.disposeBag)
+        }
+    }
+
+    private func goToAppStore() {
+        if let url = URL(string: "https://apps.apple.com/app/id6547866420") {
+            UIApplication.shared.open(url)
+        }
+    }
+    
+    @objc
+    private func appDidBecomeActive() {
+        let isWaiting = UserDefaults.standard.bool(forKey: "isWaitingForForceUpdate")
+        
+        if isWaiting {
+            UserDefaults.standard.set(false, forKey: "isWaitingForForceUpdate")
+
+            self.checkAppVersion {
+                self.checkDidSignIn()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #288 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
강제 업데이트 구현했습니다.
질문 세개 있습니다!

Remote Config에서 캐시된 값 갱신 주기를 24시간으로 설정해두었는데, 적절할까요?
```swift
        settings.minimumFetchInterval = 86400
```

Remote Config에 android를 iOS로 바꿔서 매개변수 만들어주시면 감사하겠습니다!
해당 부분은 매개변수 새로 생기면 이름 수정하고, 주석 없애고 commit 추가하겠습니다
여기서 매개변수 이름을 근데 숨기는게 더 좋나요?
```swift
            let remoteVersion = remoteConfig.configValue(forKey: "android_app_version").stringValue
//            let remoteVersion = "1.1.6"
            let majorTitle = remoteConfig.configValue(forKey: "android_major_update_title").stringValue
            let majorBody = remoteConfig.configValue(forKey: "android_major_update_body").stringValue
            let patchTitle = remoteConfig.configValue(forKey: "android_patch_update_title").stringValue
            let patchBody = remoteConfig.configValue(forKey: "android_patch_update_body").stringValue
            let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
```

여기서도 id값을 숨겨서 다시 올리는게 좋을지 궁금합니다! 앱스토어에서 링크로 공유하기 하면 자동으로 공개되는 값이라서 안숨기긴 했는데, 이부분도 수정하는게 좋을지 궁금합니다!
```swift
private func goToAppStore() {
        if let url = URL(string: "https://apps.apple.com/app/id6547866420") {
            UIApplication.shared.open(url)
        }
    }
```

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

뷰가 나타날때 앱 버전을 체크하고 completion()이 전달되었을때 로그인 로직이 실행되도록 하였습니다. 
checkDidSignIn()안에서 present를 실행하는데, present의 경우 화면이 완전히 보인 후에 실행되도록 하는게 애니메이션 충돌, 화면 깜빡임, 전환 누락 등의 예상치 못한 오류를 줄일 수 있다고 해서 viewDidLoad()말고 viewDidAppear()에 작성했습니다!

또한 NotificationCenter를 통해 앱이 포그라운드로 복귀할 때 알림 받을 수 있도록 등록해두었습니다.
1. 앱이 포그라운드로 돌아옴 → UIApplication.didBecomeActiveNotification 발생
2. 등록된 옵저버에 따라 @objc func appDidBecomeActive() 호출
3. appDidBecomeActive()에서는 UserDefaults.standard.bool(forKey: "isWaitingForForceUpdate")를 통해 앱이 업데이트 복귀 상태인지 확인 후 팝업을 다시 띄우는 로직 작동
```swift
    override func viewDidAppear(_ animated: Bool) {
        super.viewDidAppear(animated)
        
        self.checkAppVersion {
            self.checkDidSignIn()
        }
        
        NotificationCenter.default.addObserver(
            self,
            selector: #selector(appDidBecomeActive),
            name: UIApplication.didBecomeActiveNotification,
            object: nil
        )
    }
```
```swift
 @objc
    private func appDidBecomeActive() {
        let isWaiting = UserDefaults.standard.bool(forKey: "isWaitingForForceUpdate")
        
        if isWaiting {
            UserDefaults.standard.set(false, forKey: "isWaitingForForceUpdate")

            self.checkAppVersion {
                self.checkDidSignIn()
            }
        }
    }
```

viewWillDisappear애서는 다른 화면으로 넘어갈 때는 옵저버 제거해주었습니다.
```swift
override func viewWillDisappear(_ animated: Bool) {
        super.viewWillDisappear(animated)
        
        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
    }
```

하루 단위로 fetch하도록 설정해 Firebase 서버 호출은 하루에 한 번만 허용하고 그 외에는 이전 캐시 데이터 사용되도록 했습니다
```swift
extension SplashVC {
    func checkAppVersion(completion: @escaping () -> Void) {
        let remoteConfig = RemoteConfig.remoteConfig()
        let settings = RemoteConfigSettings()
        settings.minimumFetchInterval = 86400
        remoteConfig.configSettings = settings
```

여러가지 상황에 따라 분기 처리를 해두었는데, 그냥 디버깅 편할려고 로깅 용도로 사용된 것이라 딱히 기능적 동작 차이나 에러처리는 없습니다!
fetch 등에서 에러가 발생했을때 그냥 completion()을 전달해서 앱 다음화면이 실행되도록 하였습니다.
```swift
        remoteConfig.fetchAndActivate { status, error in
            if let error = error {
                print("🌷❌ Remote Config fetch error: \(error.localizedDescription)")
                completion()
                return
            }

            switch status {
            case .successFetchedFromRemote:
                print("🌷✅ Remote Config: fetched from remote")
            case .successUsingPreFetchedData:
                print("🌷ℹ️ Remote Config: using cached data")
            case .error:
                completion()
                print("🌷⚠️ Remote Config: activation error")
                return
            @unknown default:
                completion()
                print("🌷⚠️ Remote Config: unknown status")
                return
            }
```

remoteConfig 값을 가져온 후, 버전이 일치하는 경우  completion()을 전달해서 업데이트 팝업 없이 다음 로직으로 넘어가도록 하였습니다.
currentComponents와 remoteComponents를 n.n.n 에서 . 단위로 짜른 후에 첫번째 자리와 두번째 자리의 숫자가 현재 버전보다 큰 경우 isMajorUpdate를 true로 만들어주었습니다. 

isMajorUpdate의 값에 따라 팝업창에 뜰 타이틀과 본문을 결정해주었고, 어떤 종류의 팝업을 띄울 것인지 결정해 주었습니다.
```swift
            let remoteVersion = remoteConfig.configValue(forKey: "android_app_version").stringValue
//            let remoteVersion = "1.1.6"
            let majorTitle = remoteConfig.configValue(forKey: "android_major_update_title").stringValue
            let majorBody = remoteConfig.configValue(forKey: "android_major_update_body").stringValue
            let patchTitle = remoteConfig.configValue(forKey: "android_patch_update_title").stringValue
            let patchBody = remoteConfig.configValue(forKey: "android_patch_update_body").stringValue
            let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String

            guard !remoteVersion.isEmpty else {
                print("🌷❌ Remote Config에서 앱 버전이 누락됨")
                return
            }

            guard currentVersion?.compare(remoteVersion, options: .numeric) == .orderedAscending else {
                print("🌷✅ 최신 버전입니다")
                completion()
                return
            }

            let currentComponents = currentVersion?.split(separator: ".").compactMap { Int($0) } ?? [0, 0, 0]
            let remoteComponents = remoteVersion.split(separator: ".").compactMap { Int($0) }

            let currentMajor = currentComponents[0]
            let currentMinor = currentComponents[1]

            let remoteMajor = remoteComponents[0]
            let remoteMinor = remoteComponents[1]

            let isMajorUpdate = remoteMajor > currentMajor || (remoteMajor == currentMajor && remoteMinor > currentMinor)

            let type: UpdateAlertViewController.UpdateViewType = isMajorUpdate ? .force : .normal
            let titleRaw = isMajorUpdate ? majorTitle : patchTitle
            let bodyRaw = isMajorUpdate ? majorBody : patchBody
            
            let title = titleRaw.replacingOccurrences(of: "\\n", with: "\n")
            let body = bodyRaw.replacingOccurrences(of: "\\n", with: "\n")

            guard !title.isEmpty, !body.isEmpty else {
                print("🌷❌ 업데이트 문구 누락 → 팝업 표시 중단")
                completion()
                return
            }
```

업데이트 하러가기 버튼 클릭시 앱스토어로 이동하도록 하였고, 다음에 하기 버튼을 누를 경우 completion()을 전달하여 로그인 로직이 실행될 수있도록 하였습니다.
앱스토어로 이동시 다시 앱으로 돌아왔을때 팝업이 다시 뜨도록 하기 위해 UserDefaults.standard.bool(forKey: "isWaitingForForceUpdate")를 적어두었습니다! -> @objc appDidBecomeActive()에서 처리
```swift
            let updateVC = UpdateAlertViewController(updateViewType: type, title: title, discription: body)
            updateVC.modalPresentationStyle = .overFullScreen

            if let windowScene = UIApplication.shared.connectedScenes
                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
               let rootVC = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController {
                rootVC.present(updateVC, animated: false)
            }

            updateVC.rx.centerButtonTap
                .bind { [weak updateVC] in
                    UserDefaults.standard.set(true, forKey: "isWaitingForForceUpdate")
                    self.goToAppStore()
                    updateVC?.dismiss(animated: true)
                }
                .disposed(by: updateVC.disposeBag)

            updateVC.rx.rightButtonTap
                .bind { [weak updateVC] in
                    UserDefaults.standard.set(true, forKey: "isWaitingForForceUpdate")
                    self.goToAppStore()
                    updateVC?.dismiss(animated: true)
                }
                .disposed(by: updateVC.disposeBag)

            updateVC.rx.leftButtonTap
                .bind { [weak updateVC] in
                    updateVC?.dismiss(animated: true)
                    completion()
                }
                .disposed(by: updateVC.disposeBag)
        }
    }
```

앱스토어로 이동하는 코드입니다! 위에 적어둔 것처럼 id값을 숨겨서 다시 올리는게 좋을지 궁금합니다!
```swift
    private func goToAppStore() {
        if let url = URL(string: "https://apps.apple.com/app/id6547866420") {
            UIApplication.shared.open(url)
        }
    }
```

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->
현재 버전


https://github.com/user-attachments/assets/9437d26a-cb76-439c-b670-fdf1ba6a4519


소규모 업데이트

https://github.com/user-attachments/assets/60a9c306-26d1-48d7-a8cf-30e38d60f02a


대규모 업데이트 


https://github.com/user-attachments/assets/0d55278b-4106-4175-b874-2d5a41322317





<br/>

# 🖌️ Reference
1. https://monibu1548.github.io/2018/05/19/remote-config-forced-update/
2. https://ios-development.tistory.com/353
3. https://velog.io/@jwoo820/Remote-Config%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-iOS-%EB%B2%84%EC%A0%84-%EA%B4%80%EB%A6%AC
<br/>
