### PR TITLE
[Fix] #292 - 업데이트 팝업 로직 수정했습니다.

### DIFF
--- a/Terning-iOS/Terning-iOS/Presentation/Splash/SplashViewController.swift
+++ b/Terning-iOS/Terning-iOS/Presentation/Splash/SplashViewController.swift
@@ -174,20 +174,20 @@ extension SplashVC {
             updateVC.rx.centerButtonTap
                 .bind { [weak updateVC] in
                     self.goToAppStore()
-                    updateVC?.dismiss(animated: true)
+                    updateVC?.dismiss(animated: false)
                 }
                 .disposed(by: updateVC.disposeBag)
             
             updateVC.rx.rightButtonTap
                 .bind { [weak updateVC] in
                     self.goToAppStore()
-                    updateVC?.dismiss(animated: true)
+                    updateVC?.dismiss(animated: false)
                 }
                 .disposed(by: updateVC.disposeBag)
             
             updateVC.rx.leftButtonTap
                 .bind { [weak updateVC] in
-                    updateVC?.dismiss(animated: true)
+                    updateVC?.dismiss(animated: false)
                     completion()
                 }
                 .disposed(by: updateVC.disposeBag)

--- a/Terning-iOS/Terning-iOS/Presentation/Splash/SplashViewController.swift
+++ b/Terning-iOS/Terning-iOS/Presentation/Splash/SplashViewController.swift
@@ -14,11 +14,6 @@ import Then
 
 final class SplashVC: UIViewController {
     
-    // MARK: - Properties
-    
-    @UserDefaultWrapper<Bool>(key: "isWaitingForForceUpdate")
-    private var isWaitingForForceUpdate
-    
     // MARK: - UI Components
     
     private let backgroundImageView = UIImageView().then {
@@ -178,7 +173,6 @@ extension SplashVC {
             
             updateVC.rx.centerButtonTap
                 .bind { [weak updateVC] in
-                    UserDefaults.standard.set(true, forKey: "isWaitingForForceUpdate")
                     self.goToAppStore()
                     updateVC?.dismiss(animated: true)
                 }
@@ -186,7 +180,6 @@ extension SplashVC {
             
             updateVC.rx.rightButtonTap
                 .bind { [weak updateVC] in
-                    UserDefaults.standard.set(true, forKey: "isWaitingForForceUpdate")
                     self.goToAppStore()
                     updateVC?.dismiss(animated: true)
                 }
@@ -226,11 +219,8 @@ extension SplashVC {
     
     @objc
     private func appDidBecomeActive() {
-        if isWaitingForForceUpdate ?? false {
-            isWaitingForForceUpdate = false
-            checkAppVersion { [self] in
-                checkDidSignIn()
-            }
+        checkAppVersion { [self] in
+            checkDidSignIn()
         }
     }
 }

--- a/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomOnboardingButton.swift
+++ b/Terning-iOS/Terning-iOS/Resource/UIComponents/CustomOnboardingButton.swift
@@ -27,7 +27,7 @@ final class CustomOnboardingButton: UIButton {
             } else {
                 self.layer.borderColor = isHighlighted ? UIColor.grey200.cgColor : UIColor.grey200.cgColor
                 self.backgroundColor = isHighlighted ? .grey50 : .clear
-                self.setTitleColor(isHighlighted ? .grey375 : .grey375, for: .normal)
+                self.setTitleColor(isHighlighted ? .grey350 : .grey350, for: .normal)
             }
         }
     }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #292 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
isWaitingForForceUpdate관련 코드 제거
<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

isWaitingForForceUpdate는 업데이트 팝업에서 [업데이트하기] 버튼을 눌렀을 때,
앱스토어로 이동한 후 앱에 돌아왔을 때 다시 팝업을 띄우기 위한 일시적인 상태 플래그로 사용했습니다.

그러나 앱을 완전히 종료한 후 재실행할 경우, isWaitingForForceUpdate는 더 이상 유효하지 않아서 다시 팝업이 뜨지 않는 문제가 있었고

앱 복귀 시 무조건 다시 업데이트 여부 체크를하면 isWaitingForForceUpdate 플래그 없이도, 앱스토어로 이동한 후 앱에 돌아왔을 때 다시 팝업 을 띄울 수 있어서, 생각해보니 필요 없는 코드라 생각해서 삭제했습니다!

<br/>

# 📘 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->
강제 업데이트

https://github.com/user-attachments/assets/0de845aa-0e03-4747-a5da-5012ddfa9328





선택 업데이트

https://github.com/user-attachments/assets/207714bd-188e-4190-8a03-4de5675cba90

<br/>

