### PR TITLE
[Fix] #311 - 앰플 추적 로직 일부 수정

### DIFF
--- a/Terning-iOS/Terning-iOS/Info.plist
+++ b/Terning-iOS/Terning-iOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<string>NO</string>
 	<key>CFBundleIconName</key>
@@ -60,7 +62,7 @@
 	<array>
 		<string>remote-notification</string>
 	</array>
-    <key>UIUserInterfaceStyle</key>
-    <string>Light</string>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/Terning-iOS/Terning-iOS/Resource/Amplitude/AmplitudeManager.swift
+++ b/Terning-iOS/Terning-iOS/Resource/Amplitude/AmplitudeManager.swift
@@ -16,8 +16,12 @@ public struct AmplitudeManager {
 
 public extension Amplitude {
     func track(eventType: AmplitudeEventType, eventProperties: [String: Any]? = nil) {
+        #if DEBUG
+        // Debug 모드에서는 로깅하지 않음
+        return
+        #else
         let eventType: String = eventType.rawValue
-        
         AmplitudeManager.shared.track(eventType: eventType, eventProperties: eventProperties)
+        #endif
     }
 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🩵 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #311 

<br/>

# 💙 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->

1. iOS26 버전 업데이트 -> 리퀴드 미적용
2. 앰플리튜드 릴리즈 디버그 분기

<br/>

# 🅿️ PR Point
<!-- 주요 코드를 써주세요 -->

### 1. iOS26 버전 업데이트 -> 리퀴드 미적용

info.plist 에 UIDesignRequiresCompatibility 속성을 true로 해두면 임시로 리퀴드 글래스 적용을 안할 수가 있습니다.
말 그대로 임시라 대응 전까지는 사용해도 될 것 같네요~

[공식문서](https://developer.apple.com/documentation/BundleResources/Information-Property-List/UIDesignRequiresCompatibility)

<img width="547" height="42" alt="image" src="https://github.com/user-attachments/assets/eba4798a-6602-4680-a3da-b1bb56cba3cd" />


### 2. 전처리기 사용해서 앰플 추적 코드 디버그랑 릴리즈 분기 처리 했습니다.

```swift
public extension Amplitude {
    func track(eventType: AmplitudeEventType, eventProperties: [String: Any]? = nil) {
        #if DEBUG
        // Debug 모드에서는 로깅하지 않음
        return
        #else
        let eventType: String = eventType.rawValue
        AmplitudeManager.shared.track(eventType: eventType, eventProperties: eventProperties)
        #endif
    }
}

```

<br/>
